### PR TITLE
TW-4987: fix(air): align cache header test expectations with middleware implementation

### DIFF
--- a/internal/air/integration_middleware_test.go
+++ b/internal/air/integration_middleware_test.go
@@ -100,9 +100,12 @@ func TestIntegration_Middleware_CacheHeaders(t *testing.T) {
 		path          string
 		expectedCache string
 	}{
-		{"/static/css/main.css", "public, max-age=31536000, immutable"},
+		// CSS files use minimal caching for instant updates during local development
+		{"/static/css/main.css", "no-cache, must-revalidate"},
+		// API responses are never cached
 		{"/api/emails", "no-cache, no-store, must-revalidate"},
-		{"/", "public, max-age=300"},
+		// HTML pages use minimal caching for instant updates
+		{"/", "no-cache, must-revalidate"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The TestIntegration_Middleware_CacheHeaders test was failing because its expectations didn't match the actual CacheMiddleware behavior.

The middleware intentionally uses minimal caching for local development:
- CSS/JS/HTML files: "no-cache, must-revalidate" for instant updates
- API responses: "no-cache, no-store, must-revalidate" (never cached)
- Only images/fonts get longer cache times (1 day)

Updated test expectations:
- /static/css/main.css: "public, max-age=31536000, immutable" → "no-cache, must-revalidate"
- /: "public, max-age=300" → "no-cache, must-revalidate"

This aligns with the middleware's design philosophy that local development tools should prioritize instant feedback over aggressive caching.