### PR TITLE
TW-4986: fix(calendar): fix recurring events API and integration tests

### DIFF
--- a/internal/adapters/nylas/calendars_virtual_recurring.go
+++ b/internal/adapters/nylas/calendars_virtual_recurring.go
@@ -80,7 +80,7 @@ func (c *HTTPClient) GetRecurringEventInstances(ctx context.Context, grantID, ca
 	baseURL := fmt.Sprintf("%s/v3/grants/%s/events", c.baseURL, grantID)
 	queryURL := NewQueryBuilder().
 		Add("calendar_id", calendarID).
-		Add("event_id", masterEventID).
+		Add("master_event_id", masterEventID).
 		AddBool("expand_recurring", true).
 		AddInt("limit", params.Limit).
 		AddInt64("start", params.Start).

--- a/internal/adapters/nylas/calendars_virtual_recurring_test.go
+++ b/internal/adapters/nylas/calendars_virtual_recurring_test.go
@@ -176,7 +176,7 @@ func TestHTTPClient_GetRecurringEventInstances(t *testing.T) {
 
 		// Check query params
 		assert.Equal(t, "cal-123", r.URL.Query().Get("calendar_id"))
-		assert.Equal(t, "event-master", r.URL.Query().Get("event_id"))
+		assert.Equal(t, "event-master", r.URL.Query().Get("master_event_id"))
 		assert.Equal(t, "true", r.URL.Query().Get("expand_recurring"))
 		assert.Equal(t, "50", r.URL.Query().Get("limit"))
 
@@ -241,7 +241,7 @@ func TestHTTPClient_GetRecurringEventInstances_WithParams(t *testing.T) {
 
 		// Check custom query params
 		assert.Equal(t, "cal-456", r.URL.Query().Get("calendar_id"))
-		assert.Equal(t, "event-custom", r.URL.Query().Get("event_id"))
+		assert.Equal(t, "event-custom", r.URL.Query().Get("master_event_id"))
 		assert.Equal(t, "true", r.URL.Query().Get("expand_recurring"))
 		assert.Equal(t, "100", r.URL.Query().Get("limit"))
 		assert.Equal(t, "1609459200", r.URL.Query().Get("start"))

--- a/internal/cli/integration/recurring_events_test.go
+++ b/internal/cli/integration/recurring_events_test.go
@@ -30,7 +30,7 @@ func TestRecurringEventOperations(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	// Get a calendar to work with
+	// Get a writable calendar to work with
 	calendars, err := client.GetCalendars(ctx, grantID)
 	if err != nil {
 		t.Skipf("Could not get calendars: %v", err)
@@ -38,7 +38,18 @@ func TestRecurringEventOperations(t *testing.T) {
 	if len(calendars) == 0 {
 		t.Skip("No calendars available for testing")
 	}
-	calendarID := calendars[0].ID
+
+	// Find the primary calendar (the only one we can reliably modify)
+	var calendarID string
+	for _, cal := range calendars {
+		if cal.IsPrimary {
+			calendarID = cal.ID
+			break
+		}
+	}
+	if calendarID == "" {
+		t.Skip("No primary calendar available for testing")
+	}
 
 	// Create a recurring event
 	t.Run("CreateRecurringEvent", func(t *testing.T) {
@@ -163,7 +174,18 @@ func TestRecurringEventPatterns(t *testing.T) {
 	if len(calendars) == 0 {
 		t.Skip("No calendars available for testing")
 	}
-	calendarID := calendars[0].ID
+
+	// Find the primary calendar (the only one we can reliably modify)
+	var calendarID string
+	for _, cal := range calendars {
+		if cal.IsPrimary {
+			calendarID = cal.ID
+			break
+		}
+	}
+	if calendarID == "" {
+		t.Skip("No primary calendar available for testing")
+	}
 
 	now := time.Now()
 	startTime := now.Add(24 * time.Hour)


### PR DESCRIPTION
This commit fixes two issues with recurring event functionality:

1. API Parameter Fix (calendars_virtual_recurring.go):
   - Changed query parameter from `event_id` to `master_event_id`
   - The Nylas v3 API requires `master_event_id` to fetch instances of a recurring event series
   - Previous parameter caused "schema: invalid path event_id" error

2. Integration Test Fix (recurring_events_test.go):
   - Changed calendar selection from "first non-read-only" to "primary"
   - The first calendar returned is often "Holidays" (read-only)
   - Other shared calendars may also reject event creation
   - Only the primary calendar reliably allows event modifications

Updated unit tests to verify the correct API parameter is used.

Fixes: TestRecurringEventOperations, TestRecurringEventPatterns