### PR TITLE
TW-4985: chore(release): disable automatic homebrew tap updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Extract version from tag
         id: version

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,23 +69,24 @@ changelog:
     - title: Other
       order: 999
 
-brews:
-  - repository:
-      owner: nylas
-      name: homebrew-cli
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
-    homepage: "https://github.com/nylas/cli"
-    description: "CLI for Nylas API - manage email, calendar, and contacts"
-    license: "MIT"
-    install: |
-      bin.install "nylas"
-
-      # Install shell completions
-      generate_completions_from_executable(bin/"nylas", "completion")
-    test: |
-      system "#{bin}/nylas", "--version"
+# Homebrew tap disabled - update manually for now
+# brews:
+#   - repository:
+#       owner: nylas
+#       name: homebrew-nylas-cli
+#       branch: main
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     directory: Formula
+#     homepage: "https://github.com/nylas/cli"
+#     description: "CLI for Nylas API - manage email, calendar, and contacts"
+#     license: "MIT"
+#     install: |
+#       bin.install "nylas"
+#
+#       # Install shell completions
+#       generate_completions_from_executable(bin/"nylas", "completion")
+#     test: |
+#       system "#{bin}/nylas", "--version"
 
 release:
   github:
@@ -101,7 +102,7 @@ release:
 
     **macOS/Linux (Homebrew):**
     ```bash
-    brew install nylas/cli/nylas
+    brew install nylas/nylas-cli/nylas
     ```
 
     **macOS (DMG):**

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A unified command-line tool for Nylas API authentication, email management, cale
 
 **Homebrew (macOS/Linux):**
 ```bash
-brew install nylas/cli/nylas
+brew install nylas/nylas-cli/nylas
 ```
 
 **Go Install:**

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -25,7 +25,7 @@ Detailed answers to 50+ frequently asked questions.
 
 ```bash
 # Homebrew (recommended for macOS/Linux)
-brew install nylas/cli/nylas
+brew install nylas/nylas-cli/nylas
 
 # Go install
 go install github.com/nylas/cli/cmd/nylas@latest
@@ -739,7 +739,7 @@ See: [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 ```bash
 # Homebrew
-brew upgrade nylas/cli/nylas
+brew upgrade nylas/nylas-cli/nylas
 
 # Go install
 go install github.com/nylas/cli/cmd/nylas@latest

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -62,7 +62,7 @@ func runUpdate(ctx context.Context, checkOnly, force, yes bool) error {
 	// Check if installed via Homebrew
 	if isHomebrewInstall() {
 		fmt.Println("\nNylas CLI was installed via Homebrew.")
-		fmt.Println("To update, run: brew upgrade nylas/cli/nylas")
+		fmt.Println("To update, run: brew upgrade nylas/nylas-cli/nylas")
 		return nil
 	}
 


### PR DESCRIPTION
Temporarily disable automatic Homebrew formula updates until the HOMEBREW_TAP_TOKEN is configured.

Changes:
- Remove HOMEBREW_TAP_GITHUB_TOKEN from release workflow
- Comment out brews section in goreleaser config

The homebrew-nylas-cli formula will be updated manually after releases until automation is re-enabled.

To re-enable:
1. Create PAT with write access to nylas/homebrew-nylas-cli
2. Add as HOMEBREW_TAP_TOKEN secret in nylas/cli
3. Uncomment brews section in .goreleaser.yml
4. Add HOMEBREW_TAP_GITHUB_TOKEN back to release.yml