### PR TITLE
TW-4983: feat(http): add custom User-Agent header to all API requests

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,9 +20,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/nylas/cli/internal/cli.Version={{.Version}}
-      - -X github.com/nylas/cli/internal/cli.Commit={{.Commit}}
-      - -X github.com/nylas/cli/internal/cli.BuildDate={{.Date}}
+      - -X github.com/nylas/cli/internal/version.Version={{.Version}}
+      - -X github.com/nylas/cli/internal/version.Commit={{.Commit}}
+      - -X github.com/nylas/cli/internal/version.BuildDate={{.Date}}
 
 archives:
   - formats:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GOVULNCHECK_VERSION := latest
 VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS := -ldflags "-s -w -X github.com/nylas/cli/internal/cli.Version=$(VERSION) -X github.com/nylas/cli/internal/cli.Commit=$(COMMIT) -X github.com/nylas/cli/internal/cli.BuildDate=$(BUILD_DATE)"
+LDFLAGS := -ldflags "-s -w -X github.com/nylas/cli/internal/version.Version=$(VERSION) -X github.com/nylas/cli/internal/version.Commit=$(COMMIT) -X github.com/nylas/cli/internal/version.BuildDate=$(BUILD_DATE)"
 
 # ============================================================================
 # Build Targets

--- a/internal/adapters/nylas/client.go
+++ b/internal/adapters/nylas/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nylas/cli/internal/adapters/providers"
 	"github.com/nylas/cli/internal/domain"
 	"github.com/nylas/cli/internal/ports"
+	"github.com/nylas/cli/internal/version"
 	"golang.org/x/time/rate"
 )
 
@@ -166,6 +167,9 @@ func (c *HTTPClient) ensureContext(ctx context.Context) (context.Context, contex
 // This method applies rate limiting before making the request and ensures
 // the context has a timeout to prevent hanging requests.
 func (c *HTTPClient) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	// Set User-Agent header for all requests
+	req.Header.Set("User-Agent", version.UserAgent())
+
 	var lastErr error
 	var lastResp *http.Response
 
@@ -319,6 +323,7 @@ func (c *HTTPClient) doJSONRequestInternal(
 	}
 
 	// Set headers
+	req.Header.Set("User-Agent", version.UserAgent())
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/nylas/cli/internal/version"
 	"github.com/spf13/cobra"
 )
 
+// Version aliases for backwards compatibility
 var (
-	Version   = "dev"
-	Commit    = "none"
-	BuildDate = "unknown"
+	Version   = version.Version
+	Commit    = version.Commit
+	BuildDate = version.BuildDate
 )
 
 func newVersionCmd() *cobra.Command {
@@ -18,9 +20,9 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Show version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "nylas version %s\n", Version)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Commit:     %s\n", Commit)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Built:      %s\n", BuildDate)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "nylas version %s\n", version.Version)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Commit:     %s\n", version.Commit)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Built:      %s\n", version.BuildDate)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Go version: %s\n", runtime.Version())
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  OS/Arch:    %s/%s\n", runtime.GOOS, runtime.GOARCH)
 		},

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,24 @@
+// Package version provides version information for the CLI.
+// This package exists to avoid import cycles between cli and adapters packages.
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// Version is the CLI version, set via ldflags during build.
+	Version = "dev"
+
+	// Commit is the git commit hash, set via ldflags during build.
+	Commit = "none"
+
+	// BuildDate is the build timestamp, set via ldflags during build.
+	BuildDate = "unknown"
+)
+
+// UserAgent returns the User-Agent string for API requests.
+func UserAgent() string {
+	return fmt.Sprintf("nylas-cli/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,73 @@
+package version
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestUserAgent(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "dev version",
+			version: "dev",
+			want:    "nylas-cli/dev",
+		},
+		{
+			name:    "release version",
+			version: "1.0.0",
+			want:    "nylas-cli/1.0.0",
+		},
+		{
+			name:    "prerelease version",
+			version: "2.0.0-beta.1",
+			want:    "nylas-cli/2.0.0-beta.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original and restore after test
+			original := Version
+			t.Cleanup(func() { Version = original })
+
+			Version = tt.version
+			got := UserAgent()
+
+			// Check version prefix
+			if !strings.HasPrefix(got, tt.want) {
+				t.Errorf("UserAgent() = %q, want prefix %q", got, tt.want)
+			}
+
+			// Check platform info is included
+			expectedPlatform := "(" + runtime.GOOS + "/" + runtime.GOARCH + ")"
+			if !strings.HasSuffix(got, expectedPlatform) {
+				t.Errorf("UserAgent() = %q, want suffix %q", got, expectedPlatform)
+			}
+		})
+	}
+}
+
+func TestUserAgent_Format(t *testing.T) {
+	got := UserAgent()
+
+	// Format should be: nylas-cli/VERSION (OS/ARCH)
+	parts := strings.Split(got, " ")
+	if len(parts) != 2 {
+		t.Errorf("UserAgent() = %q, want format 'nylas-cli/VERSION (OS/ARCH)'", got)
+	}
+
+	// First part should start with nylas-cli/
+	if !strings.HasPrefix(parts[0], "nylas-cli/") {
+		t.Errorf("UserAgent() first part = %q, want prefix 'nylas-cli/'", parts[0])
+	}
+
+	// Second part should be (OS/ARCH)
+	if !strings.HasPrefix(parts[1], "(") || !strings.HasSuffix(parts[1], ")") {
+		t.Errorf("UserAgent() platform part = %q, want format '(OS/ARCH)'", parts[1])
+	}
+}


### PR DESCRIPTION
Add User-Agent header to track CLI version and platform in Nylas API logs.
Format: nylas-cli/VERSION (OS/ARCH)
Example: nylas-cli/3.0.0 (darwin/arm64)

Changes:
- Create internal/version package to avoid import cycles between cli
  and adapters packages
- Set User-Agent in doRequest() method which all API requests pass through
- Update ldflags in .goreleaser.yml and Makefile to use new version package
- Update internal/cli/version.go to use shared version package

Testing:
- Add internal/version/version_test.go with table-driven tests for
  UserAgent() function covering dev, release, and prerelease versions
- Add TestHTTPClient_UserAgent in client_base_test.go that uses httptest
  to verify User-Agent header is correctly set on outgoing requests