### PR TITLE
TW-5023: fix: correct Nylas dashboard URL typo

### DIFF
--- a/docs/troubleshooting/api.md
+++ b/docs/troubleshooting/api.md
@@ -53,7 +53,7 @@ Invalid API key
 nylas auth config
 
 # Verify API key in Nylas Dashboard
-# https://dashboardv3.nylas.com → Apps → Your App → API Keys
+# https://dashboard-v3.nylas.com → Apps → Your App → API Keys
 
 # Check configured key
 nylas auth status

--- a/docs/troubleshooting/auth.md
+++ b/docs/troubleshooting/auth.md
@@ -53,7 +53,7 @@ nylas auth config
 
 2. **Verify credentials are correct:**
 ```bash
-# Check your API key on https://dashboardv3.nylas.com
+# Check your API key on https://dashboard-v3.nylas.com
 # Copy the correct API key
 # Copy the correct Grant ID
 
@@ -85,7 +85,7 @@ cat ~/.config/nylas/config.yaml
 **Solutions:**
 
 1. **Get your Grant ID from Nylas Dashboard:**
-   - Login to https://dashboardv3.nylas.com
+   - Login to https://dashboard-v3.nylas.com
    - Go to "Grants" section
    - Copy your Grant ID (format: `grant_xxxx`)
 
@@ -214,7 +214,7 @@ chmod 600 ~/.config/nylas/config.yaml
 
 ```bash
 # Step 1: Get your Nylas credentials
-# Go to: https://dashboardv3.nylas.com
+# Go to: https://dashboard-v3.nylas.com
 # Create an app or use existing app
 # Get: API Key, Grant ID
 
@@ -341,7 +341,7 @@ nylas email list grant_account2
 ### Invalid API key errors:
 
 1. **Verify API key is correct:**
-   - Login to https://dashboardv3.nylas.com
+   - Login to https://dashboard-v3.nylas.com
    - Go to Apps → Your App → API Keys
    - Copy the **correct** API key
    - Format should be: `nyk_xxx...`

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -39,7 +39,7 @@ go install github.com/nylas/cli/cmd/nylas@latest
 ### Q: What do I need to get started?
 
 **A: You need:**
-1. **Nylas account** - Sign up at https://dashboardv3.nylas.com
+1. **Nylas account** - Sign up at https://dashboard-v3.nylas.com
 2. **API Key** - Create app in dashboard, get API key
 3. **Grant ID** - Connect your email account, get grant ID
 
@@ -51,7 +51,7 @@ go install github.com/nylas/cli/cmd/nylas@latest
 
 **A: Step-by-step:**
 
-1. **Go to:** https://dashboardv3.nylas.com
+1. **Go to:** https://dashboard-v3.nylas.com
 2. **Create app** (or use existing)
 3. **Get API Key:**
    - Apps → Your App → API Keys

--- a/internal/cli/auth/config.go
+++ b/internal/cli/auth/config.go
@@ -28,7 +28,7 @@ func newConfigCmd() *cobra.Command {
 		Long: `Configure Nylas API credentials.
 
 You can provide credentials via flags or interactively.
-Get your credentials from https://dashboardv3.nylas.com
+Get your credentials from https://dashboard-v3.nylas.com
 
 The CLI only requires your API Key - Client ID is auto-detected.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -50,7 +50,7 @@ The CLI only requires your API Key - Client ID is auto-detected.`,
 			// Interactive mode if API key not provided
 			if apiKey == "" {
 				fmt.Println("Configure Nylas API Credentials")
-				fmt.Println("Get your API key from: https://dashboardv3.nylas.com")
+				fmt.Println("Get your API key from: https://dashboard-v3.nylas.com")
 				fmt.Println()
 
 				fmt.Print("API Key (hidden): ")

--- a/internal/ui/server_demo_test.go
+++ b/internal/ui/server_demo_test.go
@@ -471,8 +471,8 @@ func TestCommandsJSContainsNoDashboardOldURL(t *testing.T) {
 		content := string(data)
 
 		// Verify old dashboard URL is not present
-		if strings.Contains(content, "dashboard.nylas.com") && !strings.Contains(content, "dashboardv3.nylas.com") {
-			t.Errorf("%s contains old dashboard URL (dashboard.nylas.com instead of dashboardv3.nylas.com)", path)
+		if strings.Contains(content, "dashboard.nylas.com") && !strings.Contains(content, "dashboard-v3.nylas.com") {
+			t.Errorf("%s contains old dashboard URL (dashboard.nylas.com instead of dashboard-v3.nylas.com)", path)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fixed typo in Nylas dashboard URL across documentation and code
- Changed `dashboardv3.nylas.com` → `dashboard-v3.nylas.com` (added missing hyphen)

## Files Changed

| File | Description |
|------|-------------|
| `internal/cli/auth/config.go` | CLI help text and interactive prompt |
| `docs/troubleshooting/faq.md` | FAQ getting started section |
| `docs/troubleshooting/api.md` | API troubleshooting guide |
| `docs/troubleshooting/auth.md` | Authentication troubleshooting guide |
| `internal/ui/server_demo_test.go` | Test validation for dashboard URLs |

## Test Plan

- [x] Verified build compiles successfully (`go build ./...`)
- [x] Searched codebase to confirm no remaining instances of incorrect URL
- [ ] Manual verification: confirm https://dashboard-v3.nylas.com is the correct URL