### PR TITLE
TW-5022: fix(email): collapse excessive blank lines in HTML-to-text conversion

### DIFF
--- a/internal/cli/common/html.go
+++ b/internal/cli/common/html.go
@@ -13,6 +13,8 @@ func StripHTML(s string) string {
 	s = RemoveTagWithContent(s, "head")
 
 	// Replace block-level elements with newlines before stripping tags
+	// Note: table cell elements (table, td, th, tbody, thead, tfoot) are NOT included
+	// because they're typically used for layout; tr is included to separate rows
 	blockTags := []string{"br", "p", "div", "tr", "li", "h1", "h2", "h3", "h4", "h5", "h6"}
 	for _, tag := range blockTags {
 		// Handle <br>, <br/>, <br />
@@ -52,17 +54,25 @@ func StripHTML(s string) string {
 		text = strings.ReplaceAll(text, "  ", " ")
 	}
 
-	// Collapse multiple newlines
-	for strings.Contains(text, "\n\n\n") {
-		text = strings.ReplaceAll(text, "\n\n\n", "\n\n")
-	}
-
-	// Trim spaces from each line
+	// Trim spaces from each line first
 	lines := strings.Split(text, "\n")
 	for i, line := range lines {
 		lines[i] = strings.TrimSpace(line)
 	}
-	text = strings.Join(lines, "\n")
+
+	// Remove consecutive empty lines, keeping at most one blank line
+	var cleanedLines []string
+	prevEmpty := false
+	for _, line := range lines {
+		isEmpty := line == ""
+		if isEmpty && prevEmpty {
+			continue // Skip consecutive empty lines
+		}
+		cleanedLines = append(cleanedLines, line)
+		prevEmpty = isEmpty
+	}
+
+	text = strings.Join(cleanedLines, "\n")
 
 	// Remove leading/trailing empty lines
 	return strings.TrimSpace(text)


### PR DESCRIPTION
## Summary

Fixes excessive blank lines in HTML-to-text email conversion, particularly for table-heavy marketing emails (Yahoo, Azure, ChatGPT newsletters, etc.).

**Problem:** The `StripHTML` function was creating many consecutive blank lines when processing HTML emails that use nested tables for layout. Each `</tr>` tag added a newline, and the cleanup only collapsed 3+ newlines to 2, leaving many double-newlines.

**Solution:**
- Trim whitespace from each line first
- Then collapse consecutive empty lines to at most one blank line
- Preserves paragraph separation while eliminating excessive whitespace

### Before
```
Did you just use your app password?




Hi Muhammad,




An app password for your account...
```

### After
```
Did you just use your app password?

Hi Muhammad,

An app password for your account...
```

## Changes

- `internal/cli/common/html.go`: Improved `StripHTML` function to collapse consecutive empty lines after trimming

## Test Plan

- [x] All existing `TestStripHTML` tests pass (22 test cases)
- [x] Tested with Yahoo IMAP emails (3 emails)
- [x] Tested with Microsoft Graph emails (10 emails)
- [x] `make ci` passes (fmt, vet, lint, unit tests, security scan, vuln check)

### Email Types Verified
| Provider | Email Type | Result |
|----------|------------|--------|
| Yahoo | Security notifications | ✅ Clean |
| Yahoo | OpenPGP verification | ✅ Clean |
| Microsoft | Marketing (Azure, ChatGPT) | ✅ Clean |
| Microsoft | npm OTP notifications | ✅ Clean |
| Microsoft | Nylas reminders | ✅ Clean |
| Microsoft | Plain text / replies | ✅ Clean |