### PR TITLE
TW-5021: feat(email): support inline PGP decryption for Outlook emails

### DIFF
--- a/internal/cli/email/read_decrypt.go
+++ b/internal/cli/email/read_decrypt.go
@@ -14,22 +14,31 @@ import (
 	"github.com/nylas/cli/internal/domain"
 )
 
-// decryptGPGEmail decrypts a PGP/MIME encrypted message.
+// decryptGPGEmail decrypts a PGP-encrypted message.
+// Supports both PGP/MIME (RFC 3156) and inline PGP formats.
+// Some email providers (e.g., Microsoft/Outlook) transform PGP/MIME into inline PGP.
 func decryptGPGEmail(ctx context.Context, msg *domain.Message) (*gpg.DecryptResult, error) {
 	if msg.RawMIME == "" {
 		return nil, fmt.Errorf("no raw MIME data available for decryption")
 	}
 
-	// Check if this is an encrypted message
-	contentType := extractFullContentType(msg.RawMIME)
-	if !isEncryptedMessage(contentType) {
-		return nil, fmt.Errorf("message is not PGP/MIME encrypted (Content-Type: %s)", contentType)
-	}
+	var ciphertext []byte
+	var err error
 
-	// Parse the multipart message to extract encrypted content
-	ciphertext, err := parseEncryptedMIME(msg.RawMIME)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse PGP/MIME encrypted message: %w", err)
+	// Check if this is a PGP/MIME encrypted message
+	contentType := extractFullContentType(msg.RawMIME)
+	if isEncryptedMessage(contentType) {
+		// Parse the multipart message to extract encrypted content
+		ciphertext, err = parseEncryptedMIME(msg.RawMIME)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse PGP/MIME encrypted message: %w", err)
+		}
+	} else {
+		// Try to find inline PGP content (some providers like Outlook transform PGP/MIME)
+		ciphertext = extractInlinePGP(msg.RawMIME)
+		if ciphertext == nil {
+			return nil, fmt.Errorf("message does not contain PGP encrypted content")
+		}
 	}
 
 	// Initialize GPG service
@@ -55,6 +64,76 @@ func decryptGPGEmail(ctx context.Context, msg *domain.Message) (*gpg.DecryptResu
 func isEncryptedMessage(contentType string) bool {
 	return strings.Contains(contentType, "multipart/encrypted") &&
 		strings.Contains(contentType, "application/pgp-encrypted")
+}
+
+// extractInlinePGP extracts inline PGP encrypted content from a message.
+// This handles emails where providers (e.g., Microsoft/Outlook) have transformed
+// PGP/MIME into a multipart/mixed with the PGP block as inline text.
+func extractInlinePGP(rawMIME string) []byte {
+	const pgpBegin = "-----BEGIN PGP MESSAGE-----"
+	const pgpEnd = "-----END PGP MESSAGE-----"
+
+	// First, try to find PGP content directly in the raw MIME
+	beginIdx := strings.Index(rawMIME, pgpBegin)
+	if beginIdx != -1 {
+		endIdx := strings.Index(rawMIME[beginIdx:], pgpEnd)
+		if endIdx != -1 {
+			// Include the end marker
+			pgpContent := rawMIME[beginIdx : beginIdx+endIdx+len(pgpEnd)]
+			return []byte(strings.TrimSpace(pgpContent))
+		}
+	}
+
+	// If not found directly, try parsing multipart and checking each part
+	contentType := extractFullContentType(rawMIME)
+	if !strings.Contains(contentType, "multipart/") {
+		return nil
+	}
+
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil
+	}
+
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil
+	}
+
+	headerEnd := findHeaderEnd(rawMIME)
+	if headerEnd == -1 {
+		return nil
+	}
+
+	bodySection := rawMIME[headerEnd:]
+	mr := multipart.NewReader(strings.NewReader(bodySection), boundary)
+
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil
+		}
+
+		partContent, err := io.ReadAll(part)
+		if err != nil {
+			continue
+		}
+
+		content := string(partContent)
+		beginIdx := strings.Index(content, pgpBegin)
+		if beginIdx != -1 {
+			endIdx := strings.Index(content[beginIdx:], pgpEnd)
+			if endIdx != -1 {
+				pgpContent := content[beginIdx : beginIdx+endIdx+len(pgpEnd)]
+				return []byte(strings.TrimSpace(pgpContent))
+			}
+		}
+	}
+
+	return nil
 }
 
 // parseEncryptedMIME parses a PGP/MIME encrypted message and extracts the ciphertext.


### PR DESCRIPTION
## Summary

Some email providers (notably Microsoft/Outlook) transform PGP/MIME encrypted messages when storing them. Instead of preserving the standard `multipart/encrypted; protocol="application/pgp-encrypted"` structure, they convert it to `multipart/mixed` with the PGP block as inline text.

This PR adds:
- **Inline PGP detection**: Fallback detection for `-----BEGIN PGP MESSAGE-----` blocks when the message is not in standard PGP/MIME format
- **Better error propagation**: GPG signing/encryption functions now return descriptive errors instead of generic "failed to build secure message"
- **Comprehensive tests**: Unit tests for the new `extractInlinePGP` function covering various scenarios

## Problem

When using `nylas email read <id> --decrypt` on emails received via Microsoft/Outlook, decryption fails with:
```
Error: GPG decryption failed: message is not PGP/MIME encrypted (Content-Type: multipart/mixed; ...)
```

This happens because Outlook transforms the original PGP/MIME structure:

**Original (Gmail preserves this):**
```
Content-Type: multipart/encrypted; protocol="application/pgp-encrypted"
```

**After Outlook transformation:**
```
Content-Type: multipart/mixed; boundary="..."

--boundary
Content-Type: text/plain

-----BEGIN PGP MESSAGE-----
...encrypted content...
-----END PGP MESSAGE-----
```

## Solution

The `decryptGPGEmail` function now:
1. First checks for standard PGP/MIME format (existing behavior)
2. If not PGP/MIME, searches for inline PGP blocks in the message body or MIME parts
3. Extracts and decrypts the inline PGP content

## Changes

| File | Changes |
|------|---------|
| `internal/cli/email/read_decrypt.go` | Added `extractInlinePGP()` function, updated `decryptGPGEmail()` to use fallback |
| `internal/cli/email/read_decrypt_test.go` | Added 10 test cases for `extractInlinePGP()` |
| `internal/cli/email/send_gpg.go` | Changed `build*Message()` functions to return `([]byte, error)` for proper error propagation |

## Test plan

- [x] Unit tests pass (`go test ./internal/cli/email/...`)
- [x] Linting passes (`golangci-lint run`)
- [x] CI passes (`make ci`)
- [x] Manual test: Decrypt PGP email from Gmail (PGP/MIME) ✓
- [x] Manual test: Decrypt PGP email from Outlook (inline PGP) ✓

## Compatibility

- Backward compatible: Standard PGP/MIME emails continue to work unchanged
- No breaking changes to CLI flags or API