### PR TITLE
TW-5015: fix(mcp): harden validation, security, and MCP spec compliance

### DIFF
--- a/internal/adapters/mcp/executor_calendar.go
+++ b/internal/adapters/mcp/executor_calendar.go
@@ -23,6 +23,7 @@ func (s *Server) executeListCalendars(ctx context.Context, args map[string]any) 
 			"timezone":    cal.Timezone,
 			"read_only":   cal.ReadOnly,
 			"is_primary":  cal.IsPrimary,
+			"hex_color":   cal.HexColor,
 		})
 	}
 	return toolSuccess(result)
@@ -134,7 +135,7 @@ func (s *Server) executeListEvents(ctx context.Context, args map[string]any) *To
 	calendarID := getString(args, "calendar_id", "primary")
 
 	params := &domain.EventQueryParams{
-		Limit: getInt(args, "limit", 10),
+		Limit: clampLimit(args, "limit", 10),
 	}
 	if v := getString(args, "title", ""); v != "" {
 		params.Title = v
@@ -261,15 +262,28 @@ func (s *Server) executeCreateEvent(ctx context.Context, args map[string]any) *T
 	}
 
 	if st := getInt64(args, "start_time", 0); st > 0 {
+		et := getInt64(args, "end_time", 0)
+		if et == 0 {
+			return toolError("end_time is required when start_time is provided")
+		}
+		if et <= st {
+			return toolError("end_time must be after start_time")
+		}
 		req.When = domain.EventWhen{
 			StartTime: st,
-			EndTime:   getInt64(args, "end_time", 0),
+			EndTime:   et,
 		}
 	} else if sd := getString(args, "start_date", ""); sd != "" {
+		ed := getString(args, "end_date", "")
+		if ed == "" {
+			return toolError("end_date is required when start_date is provided")
+		}
 		req.When = domain.EventWhen{
 			StartDate: sd,
-			EndDate:   getString(args, "end_date", ""),
+			EndDate:   ed,
 		}
+	} else {
+		return toolError("start_time or start_date is required")
 	}
 
 	req.Participants = parseEventParticipants(args)
@@ -328,15 +342,26 @@ func (s *Server) executeUpdateEvent(ctx context.Context, args map[string]any) *T
 	}
 
 	if st := getInt64(args, "start_time", 0); st > 0 {
+		et := getInt64(args, "end_time", 0)
+		if et == 0 {
+			return toolError("end_time is required when start_time is provided")
+		}
+		if et <= st {
+			return toolError("end_time must be after start_time")
+		}
 		when := domain.EventWhen{
 			StartTime: st,
-			EndTime:   getInt64(args, "end_time", 0),
+			EndTime:   et,
 		}
 		req.When = &when
 	} else if sd := getString(args, "start_date", ""); sd != "" {
+		ed := getString(args, "end_date", "")
+		if ed == "" {
+			return toolError("end_date is required when start_date is provided")
+		}
 		when := domain.EventWhen{
 			StartDate: sd,
-			EndDate:   getString(args, "end_date", ""),
+			EndDate:   ed,
 		}
 		req.When = &when
 	}
@@ -347,6 +372,16 @@ func (s *Server) executeUpdateEvent(ctx context.Context, args map[string]any) *T
 
 	if b := getBool(args, "busy"); b != nil {
 		req.Busy = b
+	}
+
+	if url := getString(args, "conferencing_url", ""); url != "" {
+		req.Conferencing = &domain.Conferencing{
+			Details: &domain.ConferencingDetails{URL: url},
+		}
+	}
+
+	if reminders := parseReminders(args); reminders != nil {
+		req.Reminders = reminders
 	}
 
 	event, err := s.client.UpdateEvent(ctx, grantID, calendarID, eventID, req)
@@ -387,6 +422,9 @@ func (s *Server) executeSendRSVP(ctx context.Context, args map[string]any) *Tool
 	status := getString(args, "status", "")
 	if status == "" {
 		return toolError("status is required (yes, no, or maybe)")
+	}
+	if status != "yes" && status != "no" && status != "maybe" {
+		return toolError("status must be yes, no, or maybe")
 	}
 	calendarID := getString(args, "calendar_id", "primary")
 	comment := getString(args, "comment", "")
@@ -457,11 +495,16 @@ func (s *Server) executeGetAvailability(ctx context.Context, args map[string]any
 		return toolError("duration_minutes is required")
 	}
 
+	participants := parseAvailabilityParticipants(args)
+	if len(participants) == 0 {
+		return toolError("at least one participant is required")
+	}
+
 	req := &domain.AvailabilityRequest{
 		StartTime:       startTime,
 		EndTime:         endTime,
 		DurationMinutes: durationMinutes,
-		Participants:    parseAvailabilityParticipants(args),
+		Participants:    participants,
 		IntervalMinutes: getInt(args, "interval_minutes", 0),
 		RoundTo:         getInt(args, "round_to", 0),
 	}

--- a/internal/adapters/mcp/executor_calendar_test.go
+++ b/internal/adapters/mcp/executor_calendar_test.go
@@ -401,8 +401,13 @@ func TestExecuteCreateEvent(t *testing.T) {
 			wantError: true,
 		},
 		{
+			name:      "missing time returns error",
+			args:      map[string]any{"title": "Meeting"},
+			wantError: true,
+		},
+		{
 			name: "api error propagates",
-			args: map[string]any{"title": "Meeting"},
+			args: map[string]any{"title": "Meeting", "start_time": float64(1700000000), "end_time": float64(1700003600)},
 			mockFn: func(_ context.Context, _, _ string, _ *domain.CreateEventRequest) (*domain.Event, error) {
 				return nil, errors.New("api down")
 			},

--- a/internal/adapters/mcp/executor_contacts.go
+++ b/internal/adapters/mcp/executor_contacts.go
@@ -16,7 +16,7 @@ import (
 func (s *Server) executeListContacts(ctx context.Context, args map[string]any) *ToolResponse {
 	grantID := s.resolveGrantID(args)
 	params := &domain.ContactQueryParams{
-		Limit:       getInt(args, "limit", 10),
+		Limit:       clampLimit(args, "limit", 10),
 		Email:       getString(args, "email", ""),
 		PhoneNumber: getString(args, "phone_number", ""),
 		Source:      getString(args, "source", ""),
@@ -138,6 +138,12 @@ func (s *Server) executeUpdateContact(ctx context.Context, args map[string]any) 
 	}
 	if v := getString(args, "notes", ""); v != "" {
 		req.Notes = &v
+	}
+	if emails := parseContactEmails(args); len(emails) > 0 {
+		req.Emails = emails
+	}
+	if phones := parseContactPhones(args); len(phones) > 0 {
+		req.PhoneNumbers = phones
 	}
 
 	contact, err := s.client.UpdateContact(ctx, grantID, contactID, req)

--- a/internal/adapters/mcp/executor_event_test.go
+++ b/internal/adapters/mcp/executor_event_test.go
@@ -290,8 +290,13 @@ func TestExecuteGetAvailability(t *testing.T) {
 		wantError bool
 	}{
 		{
-			name:   "happy path returns data",
-			args:   map[string]any{"start_time": float64(1700000000), "end_time": float64(1700086400), "duration_minutes": float64(30)},
+			name: "happy path returns data",
+			args: map[string]any{
+				"start_time":       float64(1700000000),
+				"end_time":         float64(1700086400),
+				"duration_minutes": float64(30),
+				"participants":     []any{map[string]any{"email": "test@example.com"}},
+			},
 			mockFn: happyMock,
 		},
 		{
@@ -310,8 +315,18 @@ func TestExecuteGetAvailability(t *testing.T) {
 			wantError: true,
 		},
 		{
+			name:      "missing participants returns error",
+			args:      map[string]any{"start_time": float64(1700000000), "end_time": float64(1700086400), "duration_minutes": float64(30)},
+			wantError: true,
+		},
+		{
 			name: "api error propagates",
-			args: map[string]any{"start_time": float64(1700000000), "end_time": float64(1700086400), "duration_minutes": float64(30)},
+			args: map[string]any{
+				"start_time":       float64(1700000000),
+				"end_time":         float64(1700086400),
+				"duration_minutes": float64(30),
+				"participants":     []any{map[string]any{"email": "test@example.com"}},
+			},
 			mockFn: func(_ context.Context, _ *domain.AvailabilityRequest) (*domain.AvailabilityResponse, error) {
 				return nil, errors.New("api down")
 			},

--- a/internal/adapters/mcp/executor_extra.go
+++ b/internal/adapters/mcp/executor_extra.go
@@ -15,7 +15,7 @@ import (
 func (s *Server) executeListThreads(ctx context.Context, args map[string]any) *ToolResponse {
 	grantID := s.resolveGrantID(args)
 	params := &domain.ThreadQueryParams{
-		Limit:   getInt(args, "limit", 10),
+		Limit:   clampLimit(args, "limit", 10),
 		Subject: getString(args, "subject", ""),
 		From:    getString(args, "from", ""),
 		To:      getString(args, "to", ""),

--- a/internal/adapters/mcp/executor_messages.go
+++ b/internal/adapters/mcp/executor_messages.go
@@ -70,8 +70,9 @@ func cleanSnippet(s string) string {
 	}
 	s = strings.TrimSpace(s)
 
-	if len(s) > maxSnippetLen {
-		s = s[:maxSnippetLen] + "..."
+	runes := []rune(s)
+	if len(runes) > maxSnippetLen {
+		s = string(runes[:maxSnippetLen]) + "..."
 	}
 	return s
 }
@@ -120,7 +121,7 @@ func formatParticipants(participants []domain.EmailParticipant) []string {
 func (s *Server) executeListMessages(ctx context.Context, args map[string]any) *ToolResponse {
 	grantID := s.resolveGrantID(args)
 	params := &domain.MessageQueryParams{
-		Limit:          getInt(args, "limit", 10),
+		Limit:          clampLimit(args, "limit", 10),
 		Subject:        getString(args, "subject", ""),
 		From:           getString(args, "from", ""),
 		To:             getString(args, "to", ""),
@@ -184,8 +185,8 @@ func (s *Server) executeGetMessage(ctx context.Context, args map[string]any) *To
 	}
 
 	body := stripHTML(msg.Body)
-	if len(body) > maxBodyLen {
-		body = body[:maxBodyLen]
+	if bodyRunes := []rune(body); len(bodyRunes) > maxBodyLen {
+		body = string(bodyRunes[:maxBodyLen])
 	}
 
 	from := ""
@@ -335,7 +336,7 @@ func (s *Server) executeSmartComposeReply(ctx context.Context, args map[string]a
 // executeListDrafts lists email drafts.
 func (s *Server) executeListDrafts(ctx context.Context, args map[string]any) *ToolResponse {
 	grantID := s.resolveGrantID(args)
-	limit := getInt(args, "limit", 10)
+	limit := clampLimit(args, "limit", 10)
 
 	drafts, err := s.client.GetDrafts(ctx, grantID, limit)
 	if err != nil {

--- a/internal/adapters/mcp/handlers.go
+++ b/internal/adapters/mcp/handlers.go
@@ -35,7 +35,10 @@ func negotiateVersion(requested string) string {
 
 // handleInitialize responds to the MCP initialize request with server capabilities.
 func (s *Server) handleInitialize(req *Request) []byte {
-	params := parseInitializeParams(req.Params)
+	params, err := parseInitializeParams(req.Params)
+	if err != nil {
+		return errorResponse(req.ID, codeInvalidParams, err.Error())
+	}
 	negotiated := negotiateVersion(params.ProtocolVersion)
 
 	// Detect user's timezone for guidance
@@ -82,8 +85,14 @@ func (s *Server) handleToolsList(req *Request) []byte {
 
 // handleToolCall dispatches a tool call to the appropriate executor.
 func (s *Server) handleToolCall(ctx context.Context, req *Request) []byte {
-	params := parseToolCallParams(req.Params)
+	params, err := parseToolCallParams(req.Params)
+	if err != nil {
+		return errorResponse(req.ID, codeInvalidParams, err.Error())
+	}
 	name := params.Name
+	if name == "" {
+		return errorResponse(req.ID, codeInvalidParams, "tool name is required")
+	}
 	args := params.Arguments
 	if args == nil {
 		args = make(map[string]any)

--- a/internal/adapters/mcp/handlers_test.go
+++ b/internal/adapters/mcp/handlers_test.go
@@ -235,7 +235,7 @@ func TestHandleToolCall_AllToolsRoute(t *testing.T) {
 		// Event tools
 		{name: "list_events", args: map[string]any{}},
 		{name: "get_event", args: map[string]any{"event_id": "e1"}},
-		{name: "create_event", args: map[string]any{"title": "test"}},
+		{name: "create_event", args: map[string]any{"title": "test", "start_time": float64(1700000000), "end_time": float64(1700003600)}},
 		{name: "update_event", args: map[string]any{"event_id": "e1"}},
 		{name: "delete_event", args: map[string]any{"event_id": "e1"}},
 		{name: "send_rsvp", args: map[string]any{"event_id": "e1", "status": "yes"}},
@@ -250,6 +250,7 @@ func TestHandleToolCall_AllToolsRoute(t *testing.T) {
 			"start_time":       float64(1000),
 			"end_time":         float64(2000),
 			"duration_minutes": float64(30),
+			"participants":     []any{map[string]any{"email": "test@example.com"}},
 		}},
 
 		// Contact tools

--- a/internal/adapters/mcp/jsonrpc.go
+++ b/internal/adapters/mcp/jsonrpc.go
@@ -3,8 +3,9 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
-	"strings"
+	"regexp"
 )
 
 // fallbackErrorResponse is a pre-built error response for when JSON marshaling fails.
@@ -40,21 +41,25 @@ type InitializeParams struct {
 }
 
 // parseToolCallParams parses ToolCallParams from raw JSON params.
-func parseToolCallParams(raw json.RawMessage) ToolCallParams {
+func parseToolCallParams(raw json.RawMessage) (ToolCallParams, error) {
 	var p ToolCallParams
 	if len(raw) > 0 {
-		_ = json.Unmarshal(raw, &p)
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return p, fmt.Errorf("invalid tool call params: %w", err)
+		}
 	}
-	return p
+	return p, nil
 }
 
 // parseInitializeParams parses InitializeParams from raw JSON params.
-func parseInitializeParams(raw json.RawMessage) InitializeParams {
+func parseInitializeParams(raw json.RawMessage) (InitializeParams, error) {
 	var p InitializeParams
 	if len(raw) > 0 {
-		_ = json.Unmarshal(raw, &p)
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return p, fmt.Errorf("invalid initialize params: %w", err)
+		}
 	}
-	return p
+	return p, nil
 }
 
 // Response represents a JSON-RPC 2.0 response.
@@ -123,15 +128,14 @@ func toolSuccessText(text string) *ToolResponse {
 	}
 }
 
+// reURL matches http:// and https:// URLs for sanitization.
+var reURL = regexp.MustCompile(`https?://\S+`)
+
 // sanitizeError wraps API errors to prevent leaking internal details.
-// Preserves the high-level message while stripping URLs and auth headers.
+// Strips all URLs (http/https) that may contain grant IDs or tokens.
 func sanitizeError(err error) string {
 	msg := err.Error()
-	// Strip full API URLs that may contain grant IDs or tokens.
-	if idx := strings.Index(msg, "https://"); idx >= 0 {
-		// Keep the error prefix, replace URL with "[API]"
-		msg = msg[:idx] + "[API]"
-	}
+	msg = reURL.ReplaceAllString(msg, "[API]")
 	return msg
 }
 
@@ -141,6 +145,21 @@ func toolError(message string) *ToolResponse {
 		Content: []ContentBlock{{Type: "text", Text: message}},
 		IsError: true,
 	}
+}
+
+// maxLimit caps the maximum number of results for list operations.
+const maxLimit = 200
+
+// clampLimit returns the limit value clamped to [1, maxLimit].
+func clampLimit(args map[string]any, key string, defaultVal int) int {
+	v := getInt(args, key, defaultVal)
+	if v <= 0 {
+		return defaultVal
+	}
+	if v > maxLimit {
+		return maxLimit
+	}
+	return v
 }
 
 // getString extracts a string argument with a default value.

--- a/internal/adapters/mcp/jsonrpc_test.go
+++ b/internal/adapters/mcp/jsonrpc_test.go
@@ -452,7 +452,7 @@ func TestParseToolCallParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := parseToolCallParams(tt.raw)
+			got, _ := parseToolCallParams(tt.raw)
 
 			if got.Name != tt.wantName {
 				t.Errorf("Name = %q, want %q", got.Name, tt.wantName)
@@ -476,7 +476,7 @@ func TestParseToolCallParams_Cursor(t *testing.T) {
 	t.Parallel()
 
 	raw := json.RawMessage(`{"name":"list_events","arguments":{},"cursor":"page-2"}`)
-	got := parseToolCallParams(raw)
+	got, _ := parseToolCallParams(raw)
 
 	if got.Cursor != "page-2" {
 		t.Errorf("Cursor = %q, want %q", got.Cursor, "page-2")
@@ -533,7 +533,7 @@ func TestParseInitializeParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := parseInitializeParams(tt.raw)
+			got, _ := parseInitializeParams(tt.raw)
 			if got.ProtocolVersion != tt.wantVersion {
 				t.Errorf("ProtocolVersion = %q, want %q", got.ProtocolVersion, tt.wantVersion)
 			}

--- a/internal/adapters/mcp/server.go
+++ b/internal/adapters/mcp/server.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -61,7 +62,7 @@ func (s *Server) RunWithIO(ctx context.Context, r io.Reader, w io.Writer) error 
 
 		payload, usedContentLength, err := readRequestPayload(reader)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return fmt.Errorf("reading stdin: %w", err)
@@ -118,14 +119,23 @@ func readRequestPayload(reader *bufio.Reader) ([]byte, bool, error) {
 		if peek[0] == '{' || peek[0] == '[' {
 			line, err := reader.ReadBytes('\n')
 			if err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					line = bytes.TrimSpace(line)
 					if len(line) == 0 {
 						return nil, false, io.EOF
 					}
+					// SEC-001: enforce size limit on newline-delimited payloads.
+					if len(line) > maxContentLength {
+						return nil, false, fmt.Errorf("payload size %d exceeds maximum %d", len(line), maxContentLength)
+					}
 					return line, false, nil
 				}
 				return nil, false, err
+			}
+
+			// SEC-001: enforce size limit on newline-delimited payloads.
+			if len(line) > maxContentLength {
+				return nil, false, fmt.Errorf("payload size %d exceeds maximum %d", len(line), maxContentLength)
 			}
 
 			line = bytes.TrimSpace(line)

--- a/internal/adapters/mcp/tools_annotations.go
+++ b/internal/adapters/mcp/tools_annotations.go
@@ -98,6 +98,7 @@ var (
 	}
 	annotationsDestructive = &ToolAnnotations{
 		DestructiveHint: boolPtr(true),
+		IdempotentHint:  boolPtr(true), // HTTP DELETE is idempotent
 	}
 	annotationsIdempotentMutating = &ToolAnnotations{
 		DestructiveHint: boolPtr(false),

--- a/internal/adapters/mcp/tools_registry.go
+++ b/internal/adapters/mcp/tools_registry.go
@@ -339,16 +339,30 @@ func registeredTools() []MCPTool {
 			Name:        "update_event",
 			Description: "Update a calendar event.",
 			InputSchema: objectSchema(map[string]JSONSchema{
-				"calendar_id":  prop("string", `Calendar ID (default "primary")`),
-				"event_id":     prop("string", "Event ID"),
-				"title":        prop("string", "Title"),
-				"description":  prop("string", "Description"),
-				"location":     prop("string", "Location"),
-				"start_time":   prop("number", "Start time"+epochDesc),
-				"end_time":     prop("number", "End time"+epochDesc),
-				"participants": participantArraySchema("Participants"),
-				"busy":         prop("boolean", "Blocks time as busy"),
-				"visibility":   {Type: "string", Desc: "Visibility", Enum: []string{"public", "private"}},
+				"calendar_id":      prop("string", `Calendar ID (default "primary")`),
+				"event_id":         prop("string", "Event ID"),
+				"title":            prop("string", "Title"),
+				"description":      prop("string", "Description"),
+				"location":         prop("string", "Location"),
+				"start_time":       prop("number", "Start time"+epochDesc),
+				"end_time":         prop("number", "End time"+epochDesc),
+				"start_date":       prop("string", "All-day start (YYYY-MM-DD)"),
+				"end_date":         prop("string", "All-day end (YYYY-MM-DD)"),
+				"participants":     participantArraySchema("Participants"),
+				"busy":             prop("boolean", "Blocks time as busy"),
+				"visibility":       {Type: "string", Desc: "Visibility", Enum: []string{"public", "private"}},
+				"conferencing_url": prop("string", "Conferencing URL"),
+				"reminders": {
+					Type: "array",
+					Desc: "Reminders",
+					Items: &JSONSchema{
+						Type: "object",
+						Properties: map[string]JSONSchema{
+							"minutes": prop("number", "Minutes before event"),
+							"method":  prop("string", "Method (email, popup)"),
+						},
+					},
+				},
 			}, []string{"event_id"}),
 		},
 		{
@@ -400,7 +414,7 @@ func registeredTools() []MCPTool {
 			InputSchema: objectSchema(map[string]JSONSchema{
 				"calendar_id": prop("string", `Calendar ID (default "primary")`),
 				"event_id":    prop("string", "Event ID"),
-				"status":      prop("string", `"yes", "no", or "maybe"`),
+				"status":      {Type: "string", Desc: `"yes", "no", or "maybe"`, Enum: []string{"yes", "no", "maybe"}},
 				"comment":     prop("string", "Optional comment"),
 			}, []string{"event_id", "status"}),
 		},
@@ -471,6 +485,28 @@ func registeredTools() []MCPTool {
 				"company_name": prop("string", "Company"),
 				"job_title":    prop("string", "Job title"),
 				"notes":        prop("string", "Notes"),
+				"emails": {
+					Type: "array",
+					Desc: "Emails",
+					Items: &JSONSchema{
+						Type: "object",
+						Properties: map[string]JSONSchema{
+							"email": prop("string", "Email"),
+							"type":  prop("string", "Type (work, home)"),
+						},
+					},
+				},
+				"phone_numbers": {
+					Type: "array",
+					Desc: "Phone numbers",
+					Items: &JSONSchema{
+						Type: "object",
+						Properties: map[string]JSONSchema{
+							"number": prop("string", "Number"),
+							"type":   prop("string", "Type (work, mobile)"),
+						},
+					},
+				},
 			}, []string{"contact_id"}),
 		},
 		{

--- a/internal/cli/mcp/mcp.go
+++ b/internal/cli/mcp/mcp.go
@@ -14,7 +14,7 @@ func NewMCPCmd() *cobra.Command {
 your Nylas email, calendar, and contacts.
 
 This runs a native MCP server that calls the Nylas API directly using
-your locally configured credentials. 37 tools across email, calendar,
+your locally configured credentials. 47 tools across email, calendar,
 contacts, and utilities.
 
 Example configuration for Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json):

--- a/internal/cli/mcp/serve.go
+++ b/internal/cli/mcp/serve.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -50,7 +51,10 @@ func runServe(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	grantID, _ := common.GetGrantID(nil)
+	grantID, err := common.GetGrantID(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not resolve grant ID: %v\n", err)
+	}
 
 	server := mcpserver.NewServer(client, grantID)
 
@@ -70,6 +74,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 
 	go func() {
 		<-sigChan


### PR DESCRIPTION
- SEC-001: enforce maxContentLength on newline-delimited JSON payloads
- SEC-004: sanitizeError now strips all http/https URLs via regex
- SEC-005: clamp limit params to max 200 across all list operations
- Fix parseToolCallParams/parseInitializeParams to return parse errors
- Add empty tool name validation before dispatch
- Use errors.Is(err, io.EOF) instead of direct comparison
- Use rune-safe truncation in cleanSnippet and body to prevent splitting multi-byte UTF-8 characters
- Require start_time/start_date with matching end field for events
- Validate end_time > start_time for timed events
- Validate RSVP status is yes/no/maybe with schema enum constraint
- Validate availability requires at least one participant
- Add IdempotentHint to destructive annotations (DELETE is idempotent)
- Add missing fields to update_event schema (start_date, end_date, conferencing_url, reminders) and executor
- Support updating contact emails and phone numbers
- Add hex_color to calendar list response for consistency
- Add signal.Stop and grant ID error logging in serve.go
- Fix tool count 37 -> 47 in mcp.go description