### PR TITLE
TW-4977: fix(email): auto-paginate search results when limit exceeds API max

### DIFF
--- a/internal/cli/email/search.go
+++ b/internal/cli/email/search.go
@@ -55,8 +55,15 @@ Examples:
 			remainingArgs := args[1:]
 
 			_, err := common.WithClient(remainingArgs, func(ctx context.Context, client ports.NylasClient, grantID string) (struct{}, error) {
+				// Auto-paginate when limit exceeds API maximum
+				needsPagination := limit > common.MaxAPILimit
+				apiLimit := limit
+				if needsPagination {
+					apiLimit = common.MaxAPILimit
+				}
+
 				params := &domain.MessageQueryParams{
-					Limit: limit,
+					Limit: apiLimit,
 				}
 
 				// Use query as subject search unless it's a wildcard
@@ -102,7 +109,30 @@ Examples:
 					params.ReceivedBefore = t.Unix()
 				}
 
-				messages, err := client.GetMessagesWithParams(ctx, grantID, params)
+				var messages []domain.Message
+				var err error
+
+				if needsPagination {
+					fetcher := func(ctx context.Context, cursor string) (common.PageResult[domain.Message], error) {
+						params.PageToken = cursor
+						resp, fetchErr := client.GetMessagesWithCursor(ctx, grantID, params)
+						if fetchErr != nil {
+							return common.PageResult[domain.Message]{}, fetchErr
+						}
+						return common.PageResult[domain.Message]{
+							Data:       resp.Data,
+							NextCursor: resp.Pagination.NextCursor,
+						}, nil
+					}
+
+					config := common.DefaultPaginationConfig()
+					config.PageSize = apiLimit
+					config.MaxItems = limit
+
+					messages, err = common.FetchAllPages(ctx, config, fetcher)
+				} else {
+					messages, err = client.GetMessagesWithParams(ctx, grantID, params)
+				}
 				if err != nil {
 					return struct{}{}, common.WrapSearchError("messages", err)
 				}
@@ -127,7 +157,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().IntVarP(&limit, "limit", "l", 20, "Maximum number of results")
+	cmd.Flags().IntVarP(&limit, "limit", "l", 20, "Maximum number of results (auto-paginates if >200)")
 	cmd.Flags().StringVar(&from, "from", "", "Filter by sender")
 	cmd.Flags().StringVar(&to, "to", "", "Filter by recipient")
 	cmd.Flags().StringVar(&subject, "subject", "", "Filter by subject")


### PR DESCRIPTION
**JIRA:** [TW-4779](https://nylas.atlassian.net/browse/TW-4779) | **Epic:** [TW-4638](https://nylas.atlassian.net/browse/TW-4638)

## Summary

- **Bug:** `nylas email search "query" --limit 250` failed with `nylas API error: limit must be lower than or equal to 200` because the raw limit was passed directly to the Nylas API, which enforces a 200-item maximum per request
- **Fix:** Added automatic pagination to the `email search` command — when `--limit` exceeds 200, the command now uses `FetchAllPages` with cursor-based pagination to collect results across multiple API requests, capping each request at 200 items
- **Consistency:** This matches the existing auto-pagination pattern already used by `email list` (lines 59-63 in `list.go`)

## What changed

**`internal/cli/email/search.go`**
- Detects when the requested limit exceeds `MaxAPILimit` (200)
- Caps the per-request API limit to 200
- Uses `common.FetchAllPages` with a cursor-based fetcher via `GetMessagesWithCursor` to paginate through results
- Stops collecting once the user's requested limit is reached
- Updated `--limit` flag help text to indicate auto-pagination support

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `--limit 50` | Single API call, works | Single API call, works (unchanged) |
| `--limit 200` | Single API call, works | Single API call, works (unchanged) |
| `--limit 250` | API error: limit must be ≤ 200 | 2 paginated requests (200 + 50), returns 250 results |
| `--limit 500` | API error: limit must be ≤ 200 | 3 paginated requests, returns 500 results |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cli/email/...` passes (no regressions)
- [x] Manual test: `nylas email search "Amazon" --limit 250` returns >200 results without error
- [x] Manual test: `nylas email search "Amazon" --limit 50` still works as before (no pagination)

[TW-4779]: https://nylas.atlassian.net/browse/TW-4779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TW-4638]: https://nylas.atlassian.net/browse/TW-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ