### PR TITLE
TW-5014: fix(tests): skip integration tests on environment-specific API limitations

### DIFF
--- a/internal/cli/integration/email_send_test.go
+++ b/internal/cli/integration/email_send_test.go
@@ -272,6 +272,10 @@ func TestCLI_EmailSearch_AdvancedFilters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			stdout, stderr, err := runCLI(tt.args...)
 			if err != nil {
+				// Microsoft Graph doesn't support combining search query with unread/starred filters
+				if strings.Contains(stderr, "not supported for Microsoft") {
+					t.Skipf("filter combination not supported for Microsoft grants")
+				}
 				t.Fatalf("email search %s failed: %v\nstderr: %s", tt.name, err, stderr)
 			}
 			t.Logf("email search %s output:\n%s", tt.name, stdout)

--- a/internal/cli/integration/virtual_calendar_test.go
+++ b/internal/cli/integration/virtual_calendar_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// skipIfSandboxLimitReached skips the test if the error indicates sandbox grant limit is hit.
+func skipIfSandboxLimitReached(t *testing.T, err error) {
+	t.Helper()
+	if err != nil && strings.Contains(err.Error(), "Maximum number of sandbox grants") {
+		t.Skip("Sandbox grant limit reached - clean up grants or upgrade plan")
+	}
+}
 
 func TestVirtualCalendarGrants(t *testing.T) {
 	apiKey := os.Getenv("NYLAS_API_KEY")
@@ -33,6 +42,7 @@ func TestVirtualCalendarGrants(t *testing.T) {
 		email := "test-conference-room-" + time.Now().Format("20060102150405") + "@example.com"
 
 		grant, err := client.CreateVirtualCalendarGrant(ctx, email)
+		skipIfSandboxLimitReached(t, err)
 		require.NoError(t, err)
 
 		// Skip test if virtual calendar grants not properly supported
@@ -108,6 +118,7 @@ func TestVirtualCalendarWorkflow(t *testing.T) {
 	// Create virtual calendar grant
 	email := "integration-test-room-" + time.Now().Format("20060102150405") + "@example.com"
 	grant, err := client.CreateVirtualCalendarGrant(ctx, email)
+	skipIfSandboxLimitReached(t, err)
 	require.NoError(t, err)
 
 	// Skip test if virtual calendar grants not properly supported


### PR DESCRIPTION
…tions

- Email search: skip unread/starred filters unsupported by Microsoft Graph
- Virtual calendar: skip when sandbox grant limit is reached