### PR TITLE
TW-5013: fix: address review findings across codebase optimization branch

### DIFF
--- a/.claude/HOOKS-CONFIG.md
+++ b/.claude/HOOKS-CONFIG.md
@@ -9,7 +9,7 @@ Hook scripts for quality enforcement. Some are wired in `settings.json`, others 
 | Hook | File | Trigger | Status |
 |------|------|---------|--------|
 | file-size-check.sh | `.claude/hooks/file-size-check.sh` | PreToolUse (Write) | **Active** |
-| auto-format.sh | `.claude/hooks/auto-format.sh` | PostToolUse (Edit) | **Active** |
+| auto-format.sh | `.claude/hooks/auto-format.sh` | PostToolUse (Edit, Write) | **Active** |
 | quality-gate.sh | `.claude/hooks/quality-gate.sh` | Stop | Available |
 | subagent-review.sh | `.claude/hooks/subagent-review.sh` | SubagentStop | Available |
 | pre-compact.sh | `.claude/hooks/pre-compact.sh` | PreCompact | Available |
@@ -24,7 +24,7 @@ Add to the `"hooks"` section in `.claude/settings.json`:
 ```json
 "Stop": [
   {
-    "matcher": "",
+    "matcher": "*",
     "hooks": [
       { "type": "command", "command": ".claude/hooks/quality-gate.sh" }
     ]
@@ -32,7 +32,7 @@ Add to the `"hooks"` section in `.claude/settings.json`:
 ],
 "SubagentStop": [
   {
-    "matcher": "",
+    "matcher": "*",
     "hooks": [
       { "type": "command", "command": ".claude/hooks/subagent-review.sh" }
     ]
@@ -40,7 +40,7 @@ Add to the `"hooks"` section in `.claude/settings.json`:
 ],
 "PreCompact": [
   {
-    "matcher": "",
+    "matcher": "*",
     "hooks": [
       { "type": "command", "command": ".claude/hooks/pre-compact.sh" }
     ]
@@ -48,7 +48,7 @@ Add to the `"hooks"` section in `.claude/settings.json`:
 ],
 "UserPromptSubmit": [
   {
-    "matcher": "",
+    "matcher": "*",
     "hooks": [
       { "type": "command", "command": ".claude/hooks/context-injector.sh" }
     ]

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -84,7 +84,7 @@ This directory contains skills, workflows, rules, agents, and shared patterns fo
 
 ---
 
-## Agents (9 Specialized)
+## Agents (8 Specialized)
 
 | Agent | Purpose |
 |-------|---------|

--- a/.claude/rules/go-quality.md
+++ b/.claude/rules/go-quality.md
@@ -7,7 +7,7 @@ Auto-applied to all Go code changes. Combines Go best practices and linting requ
 ## Mandatory Workflow
 
 ### Before Writing Code:
-1. **Check Go version:** Currently **Go 1.24.2**
+1. **Check Go version:** Module minimum **Go 1.24.2** (use latest installed version features)
 2. **Research official docs:** `go.dev/ref/spec`, `pkg.go.dev`
 3. **Find existing patterns:** Use Grep/Glob to match project style
 

--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,13 @@ test-integration:
 # -p 1: Run test packages sequentially to prevent rate limit issues
 test-integration-fast:
 	@go clean -testcache
-	NYLAS_TEST_RATE_LIMIT_RPS=$(NYLAS_TEST_RATE_LIMIT_RPS) \
-	NYLAS_TEST_RATE_LIMIT_BURST=$(NYLAS_TEST_RATE_LIMIT_BURST) \
-	NYLAS_TEST_BINARY=$(CURDIR)/bin/nylas \
-	go test ./internal/cli/integration/... -tags=integration -v -timeout 2m -p 1 \
-		-run "TestCLI_Admin|TestCLI_Timezone|TestCLI_AIConfig|TestCLI_AIProvider|TestCLI_CalendarAI_Basic|TestCLI_CalendarAI_Adapt|TestCLI_CalendarAI_Analyze_Respects|TestCLI_CalendarAI_Analyze_Default|TestCLI_CalendarAI_Analyze_Disabled|TestCLI_CalendarAI_Analyze_Focus|TestCLI_CalendarAI_Analyze_With"
+	@bash -o pipefail -c '\
+		NYLAS_TEST_RATE_LIMIT_RPS=$(NYLAS_TEST_RATE_LIMIT_RPS) \
+		NYLAS_TEST_RATE_LIMIT_BURST=$(NYLAS_TEST_RATE_LIMIT_BURST) \
+		NYLAS_TEST_BINARY=$(CURDIR)/bin/nylas \
+		go test ./internal/cli/integration/... -tags=integration -v -timeout 2m -p 1 \
+			-run "TestCLI_Admin|TestCLI_Timezone|TestCLI_AIConfig|TestCLI_AIProvider|TestCLI_CalendarAI_Basic|TestCLI_CalendarAI_Adapt|TestCLI_CalendarAI_Analyze_Respects|TestCLI_CalendarAI_Analyze_Default|TestCLI_CalendarAI_Analyze_Disabled|TestCLI_CalendarAI_Analyze_Focus|TestCLI_CalendarAI_Analyze_With" \
+	'
 
 # Clean up test resources (virtual calendars, test grants, test events, test emails, etc.)
 test-cleanup:

--- a/internal/adapters/audit/store.go
+++ b/internal/adapters/audit/store.go
@@ -3,6 +3,7 @@ package audit
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -193,13 +194,7 @@ func (s *FileStore) Query(ctx context.Context, opts *domain.AuditQueryOptions) (
 
 	// Sort files by date descending (newest first)
 	slices.SortFunc(files, func(a, b string) int {
-		if a > b {
-			return -1
-		}
-		if a < b {
-			return 1
-		}
-		return 0
+		return cmp.Compare(b, a)
 	})
 
 	var entries []domain.AuditEntry

--- a/internal/adapters/gpg/decrypt_test.go
+++ b/internal/adapters/gpg/decrypt_test.go
@@ -229,6 +229,7 @@ func isNonInteractiveGPGError(errMsg string) bool {
 		"need_passphrase",
 		"inquire_maxlen",
 		"operation cancelled",
+		"problem with the agent",
 	}
 
 	lowerErr := strings.ToLower(errMsg)

--- a/internal/adapters/mcp/proxy_forward_test.go
+++ b/internal/adapters/mcp/proxy_forward_test.go
@@ -268,13 +268,28 @@ func TestProxy_forward_ModifiesToolsList(t *testing.T) {
 		t.Fatalf("failed to parse response: %v", err)
 	}
 
-	result, _ := resp["result"].(map[string]any)
-	tools, _ := result["tools"].([]any)
-	getGrantTool, _ := tools[0].(map[string]any)
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatal("expected result to be map[string]any")
+	}
+	tools, ok := result["tools"].([]any)
+	if !ok {
+		t.Fatal("expected tools to be []any")
+	}
+	getGrantTool, ok := tools[0].(map[string]any)
+	if !ok {
+		t.Fatal("expected first tool to be map[string]any")
+	}
 
 	// Verify email is no longer required
-	inputSchema, _ := getGrantTool["inputSchema"].(map[string]any)
-	required, _ := inputSchema["required"].([]any)
+	inputSchema, ok := getGrantTool["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatal("expected inputSchema to be map[string]any")
+	}
+	required, ok := inputSchema["required"].([]any)
+	if !ok {
+		t.Fatal("expected required to be []any")
+	}
 	for _, r := range required {
 		if r == "email" {
 			t.Error("expected email to be removed from required, but it's still there")

--- a/internal/adapters/mcp/proxy_response_extra_test.go
+++ b/internal/adapters/mcp/proxy_response_extra_test.go
@@ -257,14 +257,23 @@ func TestModifyToolsListResponse_NoGetGrantTool(t *testing.T) {
 		t.Fatalf("failed to parse response: %v", err)
 	}
 
-	result, _ := parsed["result"].(map[string]any)
-	tools, _ := result["tools"].([]any)
+	result, ok := parsed["result"].(map[string]any)
+	if !ok {
+		t.Fatal("expected result to be map[string]any")
+	}
+	tools, ok := result["tools"].([]any)
+	if !ok {
+		t.Fatal("expected tools to be []any")
+	}
 
 	if len(tools) != 1 {
 		t.Errorf("expected 1 tool, got %d", len(tools))
 	}
 
-	tool, _ := tools[0].(map[string]any)
+	tool, ok := tools[0].(map[string]any)
+	if !ok {
+		t.Fatal("expected first tool to be map[string]any")
+	}
 	if tool["name"] != "list_messages" {
 		t.Errorf("expected tool name 'list_messages', got %v", tool["name"])
 	}

--- a/internal/air/server_lifecycle.go
+++ b/internal/air/server_lifecycle.go
@@ -82,6 +82,7 @@ func (s *Server) initCacheRuntime() {
 	if s.cacheSettings == nil {
 		settings, err := cache.LoadSettings(cacheCfg.BasePath)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to load cache settings: %v\n", err)
 			return
 		}
 		s.cacheSettings = settings
@@ -96,17 +97,20 @@ func (s *Server) initCacheRuntime() {
 
 	cacheManager, err := cache.NewManager(cacheCfg)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to initialize cache manager: %v\n", err)
 		return
 	}
 	s.cacheManager = cacheManager
 
 	photoDB, err := cache.OpenSharedDB(cacheCfg.BasePath, "photos.db")
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to open photo database: %v\n", err)
 		return
 	}
 
 	photoStore, err := cache.NewPhotoStore(photoDB, cacheCfg.BasePath, cache.DefaultPhotoTTL)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to initialize photo store: %v\n", err)
 		return
 	}
 	s.photoStore = photoStore

--- a/internal/air/server_template.go
+++ b/internal/air/server_template.go
@@ -149,7 +149,8 @@ func initials(email string) string {
 	return string(c)
 }
 
-// loadTemplates parses all template files.
+// loadTemplates parses all template files. Uses sync.Once since templates are
+// embedded via embed.FS and cannot change at runtime; errors are cached permanently.
 func loadTemplates() (*template.Template, error) {
 	templatesOnce.Do(func() {
 		parsedTemplates, parsedTemplatesErr = template.New("").Funcs(templateFuncs).ParseFS(

--- a/internal/cli/audit/commands_test.go
+++ b/internal/cli/audit/commands_test.go
@@ -1,6 +1,8 @@
 package audit
 
 import (
+	"bufio"
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -417,19 +419,50 @@ func TestPrintTopItems_LimitRespected(t *testing.T) {
 		"a": 1, "b": 2, "c": 3, "d": 4, "e": 5,
 		"f": 6, "g": 7, "h": 8, "i": 9, "j": 10,
 	}
-	// Just assert no panic and function runs
-	assert.NotPanics(t, func() {
-		printTopItems(counts, 3)
-	})
+
+	// Capture stdout to verify limit is respected
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printTopItems(counts, 3)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should have exactly 3 lines of output
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	assert.Equal(t, 3, len(lines), "expected 3 lines of output, got %d", len(lines))
 }
 
 func TestPrintTopItems_SortedDescending(t *testing.T) {
-	// We test the sort by capturing output indirectly via a fresh run — since
-	// printTopItems writes directly to stdout we just ensure no panic for now.
 	counts := map[string]int{"low": 1, "high": 100, "mid": 50}
-	assert.NotPanics(t, func() {
-		printTopItems(counts, 5)
-	})
+
+	// Capture stdout to verify sort order
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printTopItems(counts, 5)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Equal(t, 3, len(lines))
+
+	// First line should contain "high" (count 100), last should contain "low" (count 1)
+	assert.Contains(t, lines[0], "high")
+	assert.Contains(t, lines[1], "mid")
+	assert.Contains(t, lines[2], "low")
 }
 
 // =============================================================================
@@ -437,9 +470,6 @@ func TestPrintTopItems_SortedDescending(t *testing.T) {
 // =============================================================================
 
 func TestReadLine_ReadsAndTrims(t *testing.T) {
-	// readLine is tested indirectly via its callers in runInteractiveSetup.
-	// Here we verify its core behavior by calling it directly with a bufio.Reader
-	// built from a strings.Reader.
 	tests := []struct {
 		name     string
 		input    string
@@ -453,22 +483,9 @@ func TestReadLine_ReadsAndTrims(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reader := strings.NewReader(tt.input)
-			// readLine uses bufio.Reader internally — replicate that here.
-			got := strings.TrimSpace(readFromString(reader))
+			reader := bufio.NewReader(strings.NewReader(tt.input))
+			got := readLine(reader)
 			assert.Equal(t, tt.expected, got)
 		})
 	}
-}
-
-// readFromString reads the first line from a strings.Reader, mimicking readLine.
-func readFromString(r *strings.Reader) string {
-	buf := make([]byte, r.Len())
-	n, _ := r.Read(buf)
-	s := string(buf[:n])
-	// Strip newline like bufio.Reader.ReadString('\n') would
-	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
-		s = s[:idx]
-	}
-	return strings.TrimSpace(s)
 }

--- a/internal/cli/audit/logs_summary.go
+++ b/internal/cli/audit/logs_summary.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -118,13 +119,7 @@ func printTopItems(counts map[string]int, limit int) {
 	}
 
 	slices.SortFunc(items, func(a, b item) int {
-		if a.count > b.count {
-			return -1
-		}
-		if a.count < b.count {
-			return 1
-		}
-		return 0
+		return cmp.Compare(b.count, a.count)
 	})
 
 	// Print top items

--- a/internal/cli/integration/email_gpg_test.go
+++ b/internal/cli/integration/email_gpg_test.go
@@ -396,8 +396,11 @@ func isNonInteractiveGPGFailure(stderr string) bool {
 	markers := []string{
 		"cannot open '/dev/tty'",
 		"no pinentry",
+		"inappropriate ioctl for device",
 		"need_passphrase",
 		"inquire_maxlen",
+		"operation cancelled",
+		"problem with the agent",
 	}
 
 	for _, marker := range markers {


### PR DESCRIPTION
- Add proper type assertion checks with t.Fatal() in MCP proxy tests
- Replace verbose sort comparators with cmp.Compare() one-liners
- Add warning logs on silent cache init error paths in Air server
- Strengthen printTopItems tests to verify output content and ordering
- Fix readLine test to call actual function instead of reimplementation
- Unify GPG non-interactive error markers across test files
- Fix docs: agent count, hook trigger docs, matcher syntax, Go version
- Wrap test-integration-fast in bash pipefail for consistency