### PR TITLE
TW-4975: docs: add cli.nylas.com website link across project

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,7 +77,7 @@ changelog:
 #       branch: main
 #       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 #     directory: Formula
-#     homepage: "https://github.com/nylas/cli"
+#     homepage: "https://cli.nylas.com/"
 #     description: "CLI for Nylas API - manage email, calendar, and contacts"
 #     license: "MIT"
 #     install: |
@@ -97,6 +97,8 @@ release:
   mode: replace
   header: |
     ## Nylas CLI {{ .Version }}
+
+    **Documentation:** https://cli.nylas.com/
 
     ### Installation
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 ![Go Version](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Release](https://img.shields.io/github/v/release/nylas/cli)
+[![Website](https://img.shields.io/badge/docs-cli.nylas.com-blue)](https://cli.nylas.com/)
 
-Unified CLI for [Nylas API](https://www.nylas.com/) - manage email, calendar, and contacts across providers (Google, Microsoft, IMAP) with a single interface.
+**[Documentation](https://cli.nylas.com/)** | Unified CLI for [Nylas API](https://www.nylas.com/) - manage email, calendar, and contacts across providers (Google, Microsoft, IMAP) with a single interface.
 
 ## Installation
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,5 +1,7 @@
 # Documentation Index
 
+> **Website:** [cli.nylas.com](https://cli.nylas.com/)
+
 Quick navigation guide to find the right documentation for your needs.
 
 ---

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -62,7 +62,9 @@ OTP MANAGEMENT:
   nylas otp list       List configured accounts
 
 INTERACTIVE TUI:
-  nylas tui            Launch k9s-style terminal UI for emails`,
+  nylas tui            Launch k9s-style terminal UI for emails
+
+Documentation: https://cli.nylas.com/`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }


### PR DESCRIPTION
## Summary

Adds the documentation site URL (https://cli.nylas.com/) across all key touchpoints so users and contributors can easily discover it.

### Changes

| File | What was added |
|------|----------------|
| **README.md** | Website badge (`docs-cli.nylas.com-blue`) + "Documentation" link in the header |
| **docs/INDEX.md** | Website callout at the top of the docs hub |
| **internal/cli/root.go** | `Documentation: https://cli.nylas.com/` footer in `nylas --help` output |
| **.goreleaser.yml** | Docs link in GitHub release header + updated Homebrew formula homepage (commented out, ready for re-enable) |

Additionally, the GitHub repo "About" homepage was updated to https://cli.nylas.com/ via `gh repo edit`.

## Why

The site was live but not referenced anywhere in the project. These changes ensure visibility across:
- **GitHub visitors** — README badge + repo About section
- **CLI users** — `nylas --help` output
- **Release consumers** — GitHub release notes
- **Contributors** — docs index

## Test plan

- [x] `go build ./cmd/nylas/` passes
- [ ] Verify README badge renders correctly on GitHub
- [ ] Verify `nylas --help` shows the documentation URL at the bottom