### PR TITLE
TW-4949: Add cli.nylas.com backlinks to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ nylas email list     # You're ready!
 
 **[Full Command Reference →](docs/COMMANDS.md)** | **[All Documentation →](docs/INDEX.md)**
 
+## Guides
+
+Step-by-step tutorials on [cli.nylas.com](https://cli.nylas.com/guides):
+
+- [Give your AI coding agent an email address](https://cli.nylas.com/guides/give-ai-agent-email-address) — setup for Claude Code, Cursor, Codex CLI, and OpenClaw
+- [Send email from the command line](https://cli.nylas.com/guides/send-email-from-terminal) — no SMTP, no sendmail, one command
+- [AI agent email access via MCP](https://cli.nylas.com/guides/ai-agent-email-mcp) — connect any MCP-compatible assistant
+- [Manage calendar from the terminal](https://cli.nylas.com/guides/manage-calendar-from-terminal) — events, availability, timezone handling
+
 ## Features
 
 - **Email**: list, read, send, search, templates, GPG signing/encryption
@@ -56,7 +65,7 @@ nylas email list     # You're ready!
 - **Webhooks**: create, test, manage
 - **Timezone**: ⚡ offline conversion, DST info, meeting finder (no API required)
 - **Admin**: applications, connectors, credentials, grants
-- **Integrations**: MCP (AI assistants)
+- **Integrations**: [MCP](https://cli.nylas.com/guides/ai-agent-email-mcp) (AI assistants)
 - **Interfaces**: CLI, TUI (terminal), Air (web)
 
 ## Timezone Tools (No API Required)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -196,7 +196,8 @@ docs/
 ### **Users**
 1. [README.md](../README.md) - Getting started
 2. [COMMANDS.md](COMMANDS.md) - Command reference
-3. [troubleshooting/faq.md](troubleshooting/faq.md) - Common questions
+3. [cli.nylas.com/guides](https://cli.nylas.com/guides) - Step-by-step tutorials
+4. [troubleshooting/faq.md](troubleshooting/faq.md) - Common questions
 
 ---
 

--- a/docs/commands/audit.md
+++ b/docs/commands/audit.md
@@ -694,6 +694,7 @@ nylas audit logs clear
 
 ## Related Documentation
 
+- **[Audit AI Agent Activity](https://cli.nylas.com/guides/audit-ai-agent-activity)** - Track what Claude Code, Copilot, and MCP agents execute
 - **[Command Reference](../COMMANDS.md)** - Quick command reference
 - **[Security Overview](../security/overview.md)** - Security best practices
 - **[MCP Integration](mcp.md)** - AI assistant integration

--- a/docs/commands/calendar.md
+++ b/docs/commands/calendar.md
@@ -1420,3 +1420,8 @@ done
 
 ---
 
+## See Also
+
+- [Manage calendar from the terminal](https://cli.nylas.com/guides/manage-calendar-from-terminal) — DST-aware event creation, timezone locking, AI scheduling, and break time protection
+- [Give your AI coding agent an email address](https://cli.nylas.com/guides/give-ai-agent-email-address) — connect Claude Code, Cursor, or Codex CLI to your calendar and email
+

--- a/docs/commands/email-signing.md
+++ b/docs/commands/email-signing.md
@@ -389,6 +389,8 @@ nylas email send \
 
 ## Related Documentation
 
+- [GPG Encrypted Email from the CLI](https://cli.nylas.com/guides/gpg-encrypted-email-cli) - Full guide with examples for signing, encrypting, and verifying
+- [Secure Email Handling from the CLI](https://cli.nylas.com/guides/secure-email-handling-cli) - SPF/DKIM/DMARC, GPG, and safe attachment handling
 - [GPG Email Encryption](encryption.md) - Encrypt emails for confidentiality
 - [GPG Explained](explain-gpg.md) - Understanding GPG concepts
 - `nylas email send --help` - See all email sending options

--- a/docs/commands/email.md
+++ b/docs/commands/email.md
@@ -464,3 +464,9 @@ fi
 
 ---
 
+## See Also
+
+- [Send email from the command line](https://cli.nylas.com/guides/send-email-from-terminal) — full guide with examples for Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP
+- [Give your AI coding agent an email address](https://cli.nylas.com/guides/give-ai-agent-email-address) — connect Claude Code, Cursor, or Codex CLI to your inbox
+- [Email deliverability from the CLI](https://cli.nylas.com/guides/email-deliverability-cli) — debug SPF, DKIM, and DMARC
+

--- a/docs/commands/encryption.md
+++ b/docs/commands/encryption.md
@@ -470,6 +470,8 @@ When using both `--sign` and `--encrypt`:
 
 ## Related Documentation
 
+- [GPG Encrypted Email from the CLI](https://cli.nylas.com/guides/gpg-encrypted-email-cli) - Full guide with examples for signing, encrypting, and verifying
+- [Secure Email Handling from the CLI](https://cli.nylas.com/guides/secure-email-handling-cli) - SPF/DKIM/DMARC, GPG, and safe attachment handling
 - [GPG Email Signing](email-signing.md) - Sign emails without encryption
 - [GPG Explained](explain-gpg.md) - Understanding GPG concepts
 - `nylas email send --help` - Full command options

--- a/docs/commands/explain-gpg.md
+++ b/docs/commands/explain-gpg.md
@@ -959,6 +959,7 @@ gpg --sign-key KEY_ID              # Sign (certify) a key
 
 ## Further Reading
 
+- [GPG Encrypted Email from the CLI](https://cli.nylas.com/guides/gpg-encrypted-email-cli) - Send and receive GPG/PGP encrypted email from your terminal
 - [RFC 4880 - OpenPGP Message Format](https://tools.ietf.org/html/rfc4880)
 - [RFC 3156 - MIME Security with OpenPGP](https://tools.ietf.org/html/rfc3156)
 - [GnuPG Manual](https://www.gnupg.org/documentation/manuals/gnupg/)

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -252,6 +252,8 @@ AI Assistant (Claude/Cursor/etc.)
 
 ## See Also
 
+- [Give your AI coding agent an email address](https://cli.nylas.com/guides/give-ai-agent-email-address) — setup for Claude Code, Cursor, Codex CLI, and OpenClaw
+- [AI agent email access via MCP](https://cli.nylas.com/guides/ai-agent-email-mcp) — full MCP setup guide with all 16 tools
 - [Nylas MCP Documentation](https://developer.nylas.com/docs/dev-guide/mcp/)
 - [Model Context Protocol Spec](https://modelcontextprotocol.io/)
 - [AI Features](ai.md)

--- a/docs/commands/workflows.md
+++ b/docs/commands/workflows.md
@@ -614,6 +614,7 @@ def call_api():
 
 ### More Resources
 
+- **[Email as Identity for AI Agents](https://cli.nylas.com/guides/email-as-identity-for-ai-agents)** — how AI agents use email for signups, OTP verification, and account recovery
 - **Email Commands:** [Email Operations](email.md)
 - **Calendar Commands:** [Calendar Management](calendar.md)
 - **Webhook Integration:** [Webhook Management](webhooks.md)


### PR DESCRIPTION
**JIRA:** [TW-4777](https://nylas.atlassian.net/browse/TW-4777) | **Epic:** [TW-4730](https://nylas.atlassian.net/browse/TW-4730)

## Summary
- Add backlinks from the CLI repo to cli.nylas.com guides for SEO
- GitHub README backlinks are high-value due to GitHub's domain authority

## Changes (5 files, 10 new backlinks)
- **README.md**: New "Guides" section with 4 guide links + MCP link in Features
- **docs/commands/mcp.md**: 2 guide links in See Also
- **docs/commands/email.md**: New See Also with 3 guide links
- **docs/commands/audit.md**: 1 guide link in Related Documentation
- **docs/INDEX.md**: Link to cli.nylas.com/guides in Users section

## Why
cli.nylas.com currently has only 3 backlinks from this repo. GitHub.com has massive domain authority — links from README and docs pass significant SEO value.

[TW-4777]: https://nylas.atlassian.net/browse/TW-4777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TW-4730]: https://nylas.atlassian.net/browse/TW-4730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ