### PR TITLE
TW-4948: Dynamic grant_id discovery from upstream tools/list

### DIFF
--- a/internal/adapters/mcp/proxy.go
+++ b/internal/adapters/mcp/proxy.go
@@ -299,19 +299,48 @@ func (p *Proxy) readSSE(reader io.Reader) ([]byte, error) {
 
 // fallbackGrantTools is a static fallback used before the first tools/list response
 // is received. Once tools/list is processed, the dynamically discovered set is used instead.
+// Keep this list comprehensive to minimize the race window before dynamic discovery.
 var fallbackGrantTools = map[string]bool{
-	"get_grant":        true,
-	"list_calendars":   true,
-	"list_events":      true,
-	"create_event":     true,
-	"update_event":     true,
-	"list_messages":    true,
-	"list_threads":     true,
+	// Grants
+	"get_grant": true,
+	// Calendars
+	"list_calendars": true,
+	"get_calendar":   true,
+	// Events
+	"list_events":  true,
+	"get_event":    true,
+	"create_event": true,
+	"update_event": true,
+	"delete_event": true,
+	// Messages
+	"list_messages":  true,
+	"get_message":    true,
+	"update_message": true,
+	"delete_message": true,
+	// Threads
+	"list_threads": true,
+	"get_thread":   true,
+	// Folders
+	"list_folders":     true,
 	"get_folder_by_id": true,
-	"create_draft":     true,
-	"update_draft":     true,
-	"send_draft":       true,
-	"send_message":     true,
+	"create_folder":    true,
+	"update_folder":    true,
+	"delete_folder":    true,
+	// Drafts
+	"list_drafts":  true,
+	"get_draft":    true,
+	"create_draft": true,
+	"update_draft": true,
+	"delete_draft": true,
+	"send_draft":   true,
+	// Send
+	"send_message": true,
+	// Contacts
+	"list_contacts":  true,
+	"get_contact":    true,
+	"create_contact": true,
+	"update_contact": true,
+	"delete_contact": true,
 }
 
 // toolRequiresGrant checks whether a tool accepts grant_id, using the dynamically

--- a/internal/adapters/mcp/proxy.go
+++ b/internal/adapters/mcp/proxy.go
@@ -327,12 +327,13 @@ var fallbackGrantTools = map[string]bool{
 	"update_folder":    true,
 	"delete_folder":    true,
 	// Drafts
-	"list_drafts":  true,
-	"get_draft":    true,
-	"create_draft": true,
-	"update_draft": true,
-	"delete_draft": true,
-	"send_draft":   true,
+	"list_drafts":        true,
+	"get_draft":          true,
+	"create_draft":       true,
+	"update_draft":       true,
+	"delete_draft":       true,
+	"send_draft":         true,
+	"confirm_send_draft": true,
 	// Send
 	"send_message": true,
 	// Contacts

--- a/internal/adapters/mcp/proxy.go
+++ b/internal/adapters/mcp/proxy.go
@@ -58,6 +58,7 @@ type Proxy struct {
 	grantStore   ports.GrantStore
 	httpClient   *http.Client
 	sessionID    string
+	grantTools   map[string]bool // Dynamically discovered tools that accept grant_id
 	mu           sync.RWMutex
 }
 
@@ -296,12 +297,9 @@ func (p *Proxy) readSSE(reader io.Reader) ([]byte, error) {
 	return batch, nil
 }
 
-// toolsRequiringGrant lists tools that accept a grant_id parameter at the root level.
-// Utility tools like time converters should NOT have grant_id injected.
-// Excluded tools (don't accept grant_id at root level):
-//   - confirm_send_message, confirm_send_draft: only validate message content
-//   - availability: grant_id goes inside participants array, not at root
-var toolsRequiringGrant = map[string]bool{
+// fallbackGrantTools is a static fallback used before the first tools/list response
+// is received. Once tools/list is processed, the dynamically discovered set is used instead.
+var fallbackGrantTools = map[string]bool{
 	"get_grant":        true,
 	"list_calendars":   true,
 	"list_events":      true,
@@ -314,6 +312,19 @@ var toolsRequiringGrant = map[string]bool{
 	"update_draft":     true,
 	"send_draft":       true,
 	"send_message":     true,
+}
+
+// toolRequiresGrant checks whether a tool accepts grant_id, using the dynamically
+// discovered set from tools/list if available, falling back to the static list.
+func (p *Proxy) toolRequiresGrant(toolName string) bool {
+	p.mu.RLock()
+	gt := p.grantTools
+	p.mu.RUnlock()
+
+	if gt != nil {
+		return gt[toolName]
+	}
+	return fallbackGrantTools[toolName]
 }
 
 // injectDefaultGrant injects the default grant_id into tool call requests if not already specified.
@@ -344,9 +355,8 @@ func (p *Proxy) injectDefaultGrant(request []byte, parsed *rpcRequest) []byte {
 		return request
 	}
 
-	// Only inject grant_id for tools that need it
-	// Utility tools like epoch_to_datetime, current_time, datetime_to_epoch don't accept grant_id
-	if !toolsRequiringGrant[req.Params.Name] {
+	// Only inject grant_id for tools that accept it (dynamically discovered)
+	if !p.toolRequiresGrant(req.Params.Name) {
 		return request
 	}
 

--- a/internal/adapters/mcp/proxy_e2e_fixtures_test.go
+++ b/internal/adapters/mcp/proxy_e2e_fixtures_test.go
@@ -1,0 +1,185 @@
+package mcp
+
+// mockToolsListResponse is a realistic upstream tools/list response with a mix of
+// grant-requiring tools, utility tools, and edge cases.
+const mockToolsListResponse = `{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"result": {
+		"tools": [
+			{
+				"name": "list_messages",
+				"description": "List messages for a grant",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"get_all_query_parameters": {"type": "object"}
+					}
+				}
+			},
+			{
+				"name": "list_calendars",
+				"description": "List calendars for a grant",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"}
+					}
+				}
+			},
+			{
+				"name": "list_contacts",
+				"description": "List contacts for a grant",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"query_parameters": {"type": "object"}
+					}
+				}
+			},
+			{
+				"name": "get_contact",
+				"description": "Get a contact by ID",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"contact_id": {"type": "string"}
+					},
+					"required": ["contact_id"]
+				}
+			},
+			{
+				"name": "create_event",
+				"description": "Create a calendar event",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"calendar_id": {"type": "string"},
+						"event_request": {"type": "object"}
+					},
+					"required": ["calendar_id", "event_request"]
+				}
+			},
+			{
+				"name": "delete_event",
+				"description": "Delete a calendar event",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"calendar_id": {"type": "string"},
+						"event_id": {"type": "string"}
+					},
+					"required": ["calendar_id", "event_id"]
+				}
+			},
+			{
+				"name": "confirm_send_draft",
+				"description": "Confirm and send a draft",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"draft_id": {"type": "string"}
+					},
+					"required": ["draft_id"]
+				}
+			},
+			{
+				"name": "send_message",
+				"description": "Send a message",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"message_request": {"type": "object"},
+						"confirmation_hash": {"type": "string"}
+					},
+					"required": ["message_request", "confirmation_hash"]
+				}
+			},
+			{
+				"name": "get_grant",
+				"description": "Look up grant by email.",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"email": {"type": "string"}
+					},
+					"required": ["email"]
+				}
+			},
+			{
+				"name": "current_time",
+				"description": "Get current time in a timezone",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"timezone": {"type": "string"}
+					},
+					"required": ["timezone"]
+				}
+			},
+			{
+				"name": "epoch_to_datetime",
+				"description": "Convert epoch timestamps to human-readable dates",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"batch": {"type": "array"}
+					},
+					"required": ["batch"]
+				}
+			},
+			{
+				"name": "availability",
+				"description": "Check availability for participants",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"availability_request": {"type": "object"}
+					},
+					"required": ["availability_request"]
+				}
+			},
+			{
+				"name": "confirm_send_message",
+				"description": "Confirm message content before sending",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"message_request": {"type": "object"}
+					},
+					"required": ["message_request"]
+				}
+			},
+			{
+				"name": "brand_new_tool",
+				"description": "A hypothetical new tool added upstream",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"grant_id": {"type": "string"},
+						"payload": {"type": "object"}
+					},
+					"required": ["payload"]
+				}
+			}
+		]
+	}
+}`
+
+const mockInitializeResponse = `{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"result": {
+		"protocolVersion": "2024-11-05",
+		"capabilities": {},
+		"serverInfo": {"name": "nylas-mcp", "version": "1.0.0"},
+		"instructions": "Nylas MCP server for email and calendar."
+	}
+}`

--- a/internal/adapters/mcp/proxy_e2e_test.go
+++ b/internal/adapters/mcp/proxy_e2e_test.go
@@ -1,0 +1,451 @@
+package mcp
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+// mockMCPServer simulates the upstream Nylas MCP server for E2E proxy tests.
+// It returns realistic tools/list, initialize, and tools/call responses.
+type mockMCPServer struct {
+	t              *testing.T
+	lastToolCall   string
+	lastArgs       map[string]any
+	receivedGrant  string
+	receivedMethod string
+}
+
+func (m *mockMCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+
+	var req rpcRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"parse error"}}`))
+		return
+	}
+
+	m.receivedMethod = req.Method
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Mcp-Session-Id", "e2e-session-001")
+
+	switch req.Method {
+	case "tools/list":
+		_, _ = w.Write([]byte(mockToolsListResponse))
+	case "initialize":
+		_, _ = w.Write([]byte(mockInitializeResponse))
+	case "tools/call":
+		m.lastToolCall = req.Params.Name
+		m.lastArgs = req.Params.Arguments
+		if grantID, ok := req.Params.Arguments["grant_id"].(string); ok {
+			m.receivedGrant = grantID
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + idToJSON(req.ID) + `,"result":{"content":[{"type":"text","text":"{\"status\":\"ok\",\"tool\":\"` + req.Params.Name + `\"}"}]}}`))
+	default:
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + idToJSON(req.ID) + `,"result":{}}`))
+	}
+}
+
+func idToJSON(id any) string {
+	b, _ := json.Marshal(id)
+	return string(b)
+}
+
+// TestE2E_ProxyLifecycle tests the full proxy lifecycle:
+//  1. initialize — timezone guidance is appended
+//  2. tools/list — dynamic discovery populates grantTools
+//  3. tools/call with grant tools — grant_id is auto-injected
+//  4. tools/call with utility tools — grant_id is NOT injected
+//  5. tools/call with explicit grant_id — NOT overridden
+//  6. tools/call with new upstream tool — dynamically discovered
+//  7. get_grant without email — handled locally
+func TestE2E_ProxyLifecycle(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockMCPServer{t: t}
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	proxy := NewProxy("test-api-key", "us")
+	proxy.endpoint = server.URL
+	proxy.SetDefaultGrant("e2e-grant-abc")
+	proxy.SetGrantStore(&mockGrantStore{
+		grants: []domain.GrantInfo{
+			{ID: "e2e-grant-abc", Email: "user@example.com", Provider: "google"},
+		},
+		defaultGrant: "e2e-grant-abc",
+	})
+
+	ctx := t.Context()
+
+	// === Step 1: initialize — timezone guidance appended ===
+	t.Run("initialize_appends_timezone_guidance", func(t *testing.T) {
+		req := parseRPC(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`)
+		resp, err := proxy.forward(ctx, req.raw, req.parsed)
+		if err != nil {
+			t.Fatalf("forward failed: %v", err)
+		}
+
+		var result map[string]any
+		mustUnmarshal(t, resp, &result)
+		instructions := dig[string](result, "result", "instructions")
+		if !strings.Contains(instructions, "epoch_to_datetime") {
+			t.Error("expected timezone guidance mentioning epoch_to_datetime in instructions")
+		}
+		if !strings.Contains(instructions, "Nylas MCP server") {
+			t.Error("expected original instructions to be preserved")
+		}
+	})
+
+	// === Step 2: tools/list — discovery + get_grant modification ===
+	t.Run("tools_list_discovers_grant_tools_and_modifies_get_grant", func(t *testing.T) {
+		req := parseRPC(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+		resp, err := proxy.forward(ctx, req.raw, req.parsed)
+		if err != nil {
+			t.Fatalf("forward failed: %v", err)
+		}
+
+		var result map[string]any
+		mustUnmarshal(t, resp, &result)
+
+		tools := dig[[]any](result, "result", "tools")
+		if len(tools) == 0 {
+			t.Fatal("expected tools in response")
+		}
+
+		// Verify get_grant was modified (email no longer required)
+		for _, tool := range tools {
+			toolMap := tool.(map[string]any)
+			if toolMap["name"] == "get_grant" {
+				schema := toolMap["inputSchema"].(map[string]any)
+				required, _ := schema["required"].([]any)
+				for _, r := range required {
+					if r == "email" {
+						t.Error("expected email removed from get_grant required")
+					}
+				}
+				desc := toolMap["description"].(string)
+				if !strings.Contains(desc, "default authenticated grant") {
+					t.Error("expected get_grant description to be appended")
+				}
+			}
+		}
+
+		// Verify dynamic discovery populated grantTools
+		if proxy.grantTools == nil {
+			t.Fatal("expected grantTools to be populated after tools/list")
+		}
+
+		// Grant tools should be discovered
+		expectedGrant := []string{
+			"list_messages", "list_calendars", "list_contacts", "get_contact",
+			"create_event", "delete_event", "confirm_send_draft", "send_message",
+			"brand_new_tool",
+		}
+		for _, name := range expectedGrant {
+			if !proxy.grantTools[name] {
+				t.Errorf("expected %q to be discovered as grant tool", name)
+			}
+		}
+
+		// Utility/non-grant tools should NOT be discovered
+		expectedNoGrant := []string{
+			"current_time", "epoch_to_datetime", "availability",
+			"confirm_send_message", "get_grant",
+		}
+		for _, name := range expectedNoGrant {
+			if proxy.grantTools[name] {
+				t.Errorf("expected %q to NOT be in grantTools", name)
+			}
+		}
+	})
+
+	// === Step 3: tools/call with grant tools — grant_id auto-injected ===
+	t.Run("grant_tools_get_grant_id_injected", func(t *testing.T) {
+		grantTools := []struct {
+			name  string
+			input string
+		}{
+			{"list_messages", `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_messages","arguments":{}}}`},
+			{"list_calendars", `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_calendars","arguments":{}}}`},
+			{"list_contacts", `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_contacts","arguments":{}}}`},
+			{"create_event", `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"create_event","arguments":{"calendar_id":"primary","event_request":{}}}}`},
+			{"delete_event", `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"delete_event","arguments":{"calendar_id":"primary","event_id":"evt-1"}}}`},
+			{"confirm_send_draft", `{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"confirm_send_draft","arguments":{"draft_id":"d-1"}}}`},
+			{"brand_new_tool", `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"brand_new_tool","arguments":{"payload":{}}}}`},
+		}
+
+		for _, tt := range grantTools {
+			t.Run(tt.name, func(t *testing.T) {
+				mock.receivedGrant = ""
+				req := parseRPC(tt.input)
+				_, err := proxy.forward(ctx, req.raw, req.parsed)
+				if err != nil {
+					t.Fatalf("forward failed: %v", err)
+				}
+				if mock.receivedGrant != "e2e-grant-abc" {
+					t.Errorf("expected grant_id 'e2e-grant-abc' injected for %s, got %q", tt.name, mock.receivedGrant)
+				}
+			})
+		}
+	})
+
+	// === Step 4: utility tools — grant_id NOT injected ===
+	t.Run("utility_tools_no_grant_id_injected", func(t *testing.T) {
+		utilityTools := []struct {
+			name  string
+			input string
+		}{
+			{"current_time", `{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"current_time","arguments":{"timezone":"UTC"}}}`},
+			{"epoch_to_datetime", `{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"epoch_to_datetime","arguments":{"batch":[{"epoch_time":1700000000}]}}}`},
+			{"availability", `{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"availability","arguments":{"availability_request":{}}}}`},
+			{"confirm_send_message", `{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"confirm_send_message","arguments":{"message_request":{}}}}`},
+		}
+
+		for _, tt := range utilityTools {
+			t.Run(tt.name, func(t *testing.T) {
+				mock.receivedGrant = ""
+				req := parseRPC(tt.input)
+				_, err := proxy.forward(ctx, req.raw, req.parsed)
+				if err != nil {
+					t.Fatalf("forward failed: %v", err)
+				}
+				if mock.receivedGrant != "" {
+					t.Errorf("expected NO grant_id for %s, but got %q", tt.name, mock.receivedGrant)
+				}
+			})
+		}
+	})
+
+	// === Step 5: explicit grant_id — NOT overridden ===
+	t.Run("explicit_grant_id_not_overridden", func(t *testing.T) {
+		mock.receivedGrant = ""
+		req := parseRPC(`{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"list_messages","arguments":{"grant_id":"user-provided-grant"}}}`)
+		_, err := proxy.forward(ctx, req.raw, req.parsed)
+		if err != nil {
+			t.Fatalf("forward failed: %v", err)
+		}
+		if mock.receivedGrant != "user-provided-grant" {
+			t.Errorf("expected user-provided grant_id preserved, got %q", mock.receivedGrant)
+		}
+	})
+
+	// === Step 6: explicit identifier — grant_id NOT injected ===
+	t.Run("identifier_prevents_grant_injection", func(t *testing.T) {
+		mock.receivedGrant = ""
+		req := parseRPC(`{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"list_messages","arguments":{"identifier":"user@example.com"}}}`)
+		_, err := proxy.forward(ctx, req.raw, req.parsed)
+		if err != nil {
+			t.Fatalf("forward failed: %v", err)
+		}
+		if mock.receivedGrant != "" {
+			t.Errorf("expected no grant_id when identifier is set, got %q", mock.receivedGrant)
+		}
+	})
+
+	// === Step 7: get_grant without email — local response ===
+	t.Run("get_grant_without_email_handled_locally", func(t *testing.T) {
+		var req rpcRequest
+		raw := []byte(`{"jsonrpc":"2.0","id":16,"method":"tools/call","params":{"name":"get_grant","arguments":{}}}`)
+		_ = json.Unmarshal(raw, &req)
+
+		resp, handled := proxy.handleLocalToolCall(&req)
+		if !handled {
+			t.Fatal("expected get_grant without email to be handled locally")
+		}
+
+		var result struct {
+			Result struct {
+				Content []struct {
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"result"`
+		}
+		mustUnmarshal(t, resp, &result)
+
+		if len(result.Result.Content) == 0 {
+			t.Fatal("expected content in local get_grant response")
+		}
+
+		var grant struct {
+			GrantID  string `json:"grant_id"`
+			Email    string `json:"email"`
+			Provider string `json:"provider"`
+		}
+		mustUnmarshal(t, []byte(result.Result.Content[0].Text), &grant)
+
+		if grant.GrantID != "e2e-grant-abc" {
+			t.Errorf("expected grant_id 'e2e-grant-abc', got %q", grant.GrantID)
+		}
+		if grant.Email != "user@example.com" {
+			t.Errorf("expected email 'user@example.com', got %q", grant.Email)
+		}
+	})
+
+	// === Step 8: get_grant with email — passes through to server ===
+	t.Run("get_grant_with_email_passes_through", func(t *testing.T) {
+		var req rpcRequest
+		raw := []byte(`{"jsonrpc":"2.0","id":17,"method":"tools/call","params":{"name":"get_grant","arguments":{"email":"other@example.com"}}}`)
+		_ = json.Unmarshal(raw, &req)
+
+		_, handled := proxy.handleLocalToolCall(&req)
+		if handled {
+			t.Error("expected get_grant with email to pass through to server")
+		}
+	})
+
+	// === Step 9: session ID stored from server response ===
+	t.Run("session_id_stored", func(t *testing.T) {
+		if proxy.sessionID != "e2e-session-001" {
+			t.Errorf("expected session ID 'e2e-session-001', got %q", proxy.sessionID)
+		}
+	})
+
+	// === Step 10: non-tools/call method passes through ===
+	t.Run("non_tools_method_passes_through", func(t *testing.T) {
+		mock.receivedMethod = ""
+		req := parseRPC(`{"jsonrpc":"2.0","id":18,"method":"notifications/initialized","params":{}}`)
+		_, err := proxy.forward(ctx, req.raw, req.parsed)
+		if err != nil {
+			t.Fatalf("forward failed: %v", err)
+		}
+		if mock.receivedMethod != "notifications/initialized" {
+			t.Errorf("expected method forwarded as-is, got %q", mock.receivedMethod)
+		}
+	})
+}
+
+// TestE2E_DiscoveryOverridesFallback verifies that after tools/list,
+// a tool NOT in the static fallback but present upstream gets grant injection.
+func TestE2E_DiscoveryOverridesFallback(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockMCPServer{t: t}
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	proxy := NewProxy("test-api-key", "us")
+	proxy.endpoint = server.URL
+	proxy.SetDefaultGrant("grant-xyz")
+
+	ctx := t.Context()
+
+	// Before discovery: brand_new_tool is NOT in fallback
+	if proxy.toolRequiresGrant("brand_new_tool") {
+		t.Fatal("brand_new_tool should NOT be in fallback")
+	}
+
+	// Trigger discovery via tools/list
+	req := parseRPC(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	_, err := proxy.forward(ctx, req.raw, req.parsed)
+	if err != nil {
+		t.Fatalf("forward failed: %v", err)
+	}
+
+	// After discovery: brand_new_tool IS now known
+	if !proxy.toolRequiresGrant("brand_new_tool") {
+		t.Fatal("brand_new_tool should be discovered after tools/list")
+	}
+
+	// Verify grant injection works for the newly discovered tool
+	mock.receivedGrant = ""
+	callReq := parseRPC(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"brand_new_tool","arguments":{"payload":{}}}}`)
+	_, err = proxy.forward(ctx, callReq.raw, callReq.parsed)
+	if err != nil {
+		t.Fatalf("forward failed: %v", err)
+	}
+	if mock.receivedGrant != "grant-xyz" {
+		t.Errorf("expected grant_id injected for brand_new_tool, got %q", mock.receivedGrant)
+	}
+}
+
+// TestE2E_NoGrantSetSkipsInjection verifies that when no default grant
+// is configured, tools/call passes through without grant_id.
+func TestE2E_NoGrantSetSkipsInjection(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockMCPServer{t: t}
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	proxy := NewProxy("test-api-key", "us")
+	proxy.endpoint = server.URL
+	// No SetDefaultGrant called
+
+	ctx := t.Context()
+
+	mock.receivedGrant = ""
+	req := parseRPC(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_messages","arguments":{}}}`)
+	_, err := proxy.forward(ctx, req.raw, req.parsed)
+	if err != nil {
+		t.Fatalf("forward failed: %v", err)
+	}
+	if mock.receivedGrant != "" {
+		t.Errorf("expected no grant_id when none configured, got %q", mock.receivedGrant)
+	}
+}
+
+// TestE2E_ServerError tests proxy behavior when upstream returns errors.
+func TestE2E_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	proxy := NewProxy("test-api-key", "us")
+	proxy.endpoint = server.URL
+
+	req := parseRPC(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	_, err := proxy.forward(t.Context(), req.raw, req.parsed)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to mention status 500, got: %v", err)
+	}
+}
+
+// --- helpers ---
+
+type parsedRPC struct {
+	raw    []byte
+	parsed *rpcRequest
+}
+
+func parseRPC(s string) parsedRPC {
+	var req rpcRequest
+	_ = json.Unmarshal([]byte(s), &req)
+	return parsedRPC{raw: []byte(s), parsed: &req}
+}
+
+func mustUnmarshal(t *testing.T, data []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("failed to unmarshal: %v\ndata: %s", err, string(data))
+	}
+}
+
+// dig navigates nested maps to extract a typed value.
+func dig[T any](m map[string]any, keys ...string) T {
+	var zero T
+	current := any(m)
+	for _, k := range keys {
+		cm, ok := current.(map[string]any)
+		if !ok {
+			return zero
+		}
+		current = cm[k]
+	}
+	v, _ := current.(T)
+	return v
+}

--- a/internal/adapters/mcp/proxy_forward_test.go
+++ b/internal/adapters/mcp/proxy_forward_test.go
@@ -176,6 +176,24 @@ func TestProxy_injectDefaultGrant(t *testing.T) {
 			wantGrant:  true,
 			grantValue: "my-grant-id",
 		},
+		{
+			name:       "injects grant_id for delete_event",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_event","arguments":{"event_id":"evt-123"}}}`,
+			wantGrant:  true,
+			grantValue: "my-grant-id",
+		},
+		{
+			name:       "injects grant_id for list_contacts",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_contacts","arguments":{}}}`,
+			wantGrant:  true,
+			grantValue: "my-grant-id",
+		},
+		{
+			name:       "injects grant_id for get_contact",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_contact","arguments":{"contact_id":"ct-456"}}}`,
+			wantGrant:  true,
+			grantValue: "my-grant-id",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapters/mcp/proxy_forward_test.go
+++ b/internal/adapters/mcp/proxy_forward_test.go
@@ -160,9 +160,10 @@ func TestProxy_injectDefaultGrant(t *testing.T) {
 			wantGrant: false,
 		},
 		{
-			name:      "does not inject grant_id for confirm_send_draft (validates draft content only)",
-			input:     `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"confirm_send_draft","arguments":{"grant_id":"abc","draft_id":"123"}}}`,
-			wantGrant: false,
+			name:       "injects grant_id for confirm_send_draft",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"confirm_send_draft","arguments":{"draft_id":"123"}}}`,
+			wantGrant:  true,
+			grantValue: "my-grant-id",
 		},
 		{
 			name:       "injects grant_id for create_event",

--- a/internal/adapters/mcp/proxy_modify_test.go
+++ b/internal/adapters/mcp/proxy_modify_test.go
@@ -195,7 +195,7 @@ func TestProxy_toolRequiresGrant_Fallback(t *testing.T) {
 	for _, name := range []string{
 		"list_messages", "get_message", "list_events", "create_event", "delete_event",
 		"list_calendars", "get_calendar", "list_contacts", "get_contact",
-		"create_draft", "send_message", "get_folder_by_id",
+		"create_draft", "confirm_send_draft", "send_message", "get_folder_by_id",
 	} {
 		if !proxy.toolRequiresGrant(name) {
 			t.Errorf("expected fallback to include %q", name)
@@ -205,7 +205,7 @@ func TestProxy_toolRequiresGrant_Fallback(t *testing.T) {
 	// Utility tools and tools where grant_id is nested should NOT be in fallback
 	for _, name := range []string{
 		"current_time", "epoch_to_datetime", "datetime_to_epoch",
-		"availability", "confirm_send_message", "confirm_send_draft",
+		"availability", "confirm_send_message",
 	} {
 		if proxy.toolRequiresGrant(name) {
 			t.Errorf("expected fallback to exclude %q", name)

--- a/internal/adapters/mcp/proxy_modify_test.go
+++ b/internal/adapters/mcp/proxy_modify_test.go
@@ -192,15 +192,24 @@ func TestProxy_toolRequiresGrant_Fallback(t *testing.T) {
 	proxy := NewProxy("test-api-key", "us")
 
 	// Before tools/list, should use fallback
-	if !proxy.toolRequiresGrant("list_messages") {
-		t.Error("expected fallback to include list_messages")
+	for _, name := range []string{
+		"list_messages", "get_message", "list_events", "create_event", "delete_event",
+		"list_calendars", "get_calendar", "list_contacts", "get_contact",
+		"create_draft", "send_message", "get_folder_by_id",
+	} {
+		if !proxy.toolRequiresGrant(name) {
+			t.Errorf("expected fallback to include %q", name)
+		}
 	}
-	if proxy.toolRequiresGrant("current_time") {
-		t.Error("expected fallback to exclude current_time")
-	}
-	// A tool not in the fallback (but present upstream)
-	if proxy.toolRequiresGrant("get_contact") {
-		t.Error("expected fallback to NOT include get_contact (not in static list)")
+
+	// Utility tools and tools where grant_id is nested should NOT be in fallback
+	for _, name := range []string{
+		"current_time", "epoch_to_datetime", "datetime_to_epoch",
+		"availability", "confirm_send_message", "confirm_send_draft",
+	} {
+		if proxy.toolRequiresGrant(name) {
+			t.Errorf("expected fallback to exclude %q", name)
+		}
 	}
 }
 

--- a/internal/adapters/mcp/proxy_modify_test.go
+++ b/internal/adapters/mcp/proxy_modify_test.go
@@ -97,6 +97,113 @@ func TestProxy_modifyInitializeResponse(t *testing.T) {
 	}
 }
 
+func TestProxy_modifyToolsListResponse_DiscoverGrantTools(t *testing.T) {
+	t.Parallel()
+
+	proxy := NewProxy("test-api-key", "us")
+
+	// Verify grantTools is nil before tools/list
+	if proxy.grantTools != nil {
+		t.Fatal("expected grantTools to be nil initially")
+	}
+
+	// Simulate a tools/list response with various tools
+	response := `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"result": {
+			"tools": [
+				{
+					"name": "list_messages",
+					"description": "List messages",
+					"inputSchema": {
+						"type": "object",
+						"properties": {
+							"grant_id": {"type": "string"},
+							"limit": {"type": "integer"}
+						}
+					}
+				},
+				{
+					"name": "get_contact",
+					"description": "Get a contact",
+					"inputSchema": {
+						"type": "object",
+						"properties": {
+							"grant_id": {"type": "string"},
+							"contact_id": {"type": "string"}
+						}
+					}
+				},
+				{
+					"name": "current_time",
+					"description": "Get current time",
+					"inputSchema": {
+						"type": "object",
+						"properties": {}
+					}
+				},
+				{
+					"name": "delete_event",
+					"description": "Delete an event",
+					"inputSchema": {
+						"type": "object",
+						"properties": {
+							"grant_id": {"type": "string"},
+							"event_id": {"type": "string"}
+						}
+					}
+				}
+			]
+		}
+	}`
+
+	proxy.modifyToolsListResponse([]byte(response))
+
+	// Verify dynamic discovery
+	if proxy.grantTools == nil {
+		t.Fatal("expected grantTools to be populated after tools/list")
+	}
+
+	// Tools with grant_id should be discovered
+	for _, name := range []string{"list_messages", "get_contact", "delete_event"} {
+		if !proxy.grantTools[name] {
+			t.Errorf("expected %q to be discovered as a grant tool", name)
+		}
+	}
+
+	// Tools without grant_id should NOT be included
+	if proxy.grantTools["current_time"] {
+		t.Error("expected current_time to NOT be a grant tool")
+	}
+
+	// toolRequiresGrant should now use the dynamic set
+	if !proxy.toolRequiresGrant("get_contact") {
+		t.Error("expected toolRequiresGrant to return true for dynamically discovered tool")
+	}
+	if proxy.toolRequiresGrant("current_time") {
+		t.Error("expected toolRequiresGrant to return false for utility tool")
+	}
+}
+
+func TestProxy_toolRequiresGrant_Fallback(t *testing.T) {
+	t.Parallel()
+
+	proxy := NewProxy("test-api-key", "us")
+
+	// Before tools/list, should use fallback
+	if !proxy.toolRequiresGrant("list_messages") {
+		t.Error("expected fallback to include list_messages")
+	}
+	if proxy.toolRequiresGrant("current_time") {
+		t.Error("expected fallback to exclude current_time")
+	}
+	// A tool not in the fallback (but present upstream)
+	if proxy.toolRequiresGrant("get_contact") {
+		t.Error("expected fallback to NOT include get_contact (not in static list)")
+	}
+}
+
 func TestProxy_modifyToolsListResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapters/mcp/proxy_response.go
+++ b/internal/adapters/mcp/proxy_response.go
@@ -148,9 +148,8 @@ func (p *Proxy) createErrorResponse(req *rpcRequest, originalErr error) []byte {
 	return respBytes
 }
 
-// modifyToolsListResponse modifies the tools/list response to make get_grant email optional.
-// This allows AI assistants to call get_grant without providing an email,
-// which triggers the local grant lookup in handleLocalToolCall.
+// modifyToolsListResponse modifies the tools/list response to make get_grant email optional,
+// and dynamically discovers which tools accept grant_id for automatic injection.
 func (p *Proxy) modifyToolsListResponse(response []byte) []byte {
 	// Parse the JSON-RPC response
 	var rpcResp map[string]any
@@ -169,7 +168,8 @@ func (p *Proxy) modifyToolsListResponse(response []byte) []byte {
 		return response
 	}
 
-	// Find and modify the get_grant tool
+	// Discover which tools accept grant_id and modify get_grant
+	discovered := make(map[string]bool)
 	for _, tool := range tools {
 		toolMap, ok := tool.(map[string]any)
 		if !ok {
@@ -177,34 +177,45 @@ func (p *Proxy) modifyToolsListResponse(response []byte) []byte {
 		}
 
 		name, ok := toolMap["name"].(string)
-		if !ok || name != "get_grant" {
+		if !ok {
 			continue
 		}
 
-		// Found get_grant - modify its inputSchema to make email optional
 		inputSchema, ok := toolMap["inputSchema"].(map[string]any)
 		if !ok {
 			continue
 		}
 
-		// Remove "email" from required array
-		required, ok := inputSchema["required"].([]any)
-		if ok {
-			newRequired := make([]any, 0, len(required))
-			for _, r := range required {
-				if r != "email" {
-					newRequired = append(newRequired, r)
-				}
+		// Check if this tool has grant_id in its properties
+		if props, ok := inputSchema["properties"].(map[string]any); ok {
+			if _, hasGrantID := props["grant_id"]; hasGrantID {
+				discovered[name] = true
 			}
-			inputSchema["required"] = newRequired
 		}
 
-		// Update the description to indicate email is optional
-		if desc, ok := toolMap["description"].(string); ok {
-			toolMap["description"] = desc + " If email is not provided, returns the default authenticated grant."
-		}
+		// Modify get_grant to make email optional
+		if name == "get_grant" {
+			if required, ok := inputSchema["required"].([]any); ok {
+				newRequired := make([]any, 0, len(required))
+				for _, r := range required {
+					if r != "email" {
+						newRequired = append(newRequired, r)
+					}
+				}
+				inputSchema["required"] = newRequired
+			}
 
-		break
+			if desc, ok := toolMap["description"].(string); ok {
+				toolMap["description"] = desc + " If email is not provided, returns the default authenticated grant."
+			}
+		}
+	}
+
+	// Cache the discovered grant tools for use in injectDefaultGrant
+	if len(discovered) > 0 {
+		p.mu.Lock()
+		p.grantTools = discovered
+		p.mu.Unlock()
 	}
 
 	// Re-marshal the modified response

--- a/internal/cli/mcp/serve.go
+++ b/internal/cli/mcp/serve.go
@@ -22,33 +22,18 @@ func newServeCmd() *cobra.Command {
 		Long: `Start the MCP server to enable AI assistants to interact with Nylas.
 
 This command acts as a proxy to the official Nylas MCP server, providing
-access to all Nylas email and calendar tools through the Model Context Protocol.
+access to all Nylas email, calendar, and contacts tools through the
+Model Context Protocol.
+
+The proxy dynamically discovers available tools from the upstream Nylas
+MCP server and adds local enhancements:
+  - Automatic grant_id injection (no need to specify which account)
+  - Local grant lookup (get_grant without email)
+  - Timezone-aware timestamp display
+  - Secure credential handling via system keyring
 
 The server communicates via STDIO (standard input/output) and requires
 Nylas credentials to be configured via 'nylas auth login'.
-
-Available tools (from Nylas MCP):
-
-  Messages:
-    list_messages     - Search and retrieve emails
-    list_threads      - List email threads
-    create_draft      - Create a new draft
-    update_draft      - Update an existing draft
-    send_message      - Send a new email (requires confirmation)
-    send_draft        - Send a draft (requires confirmation)
-
-  Calendar:
-    list_calendars    - List all calendars
-    list_events       - List calendar events
-    create_event      - Create a new event
-    update_event      - Update an existing event
-    availability      - Check availability
-
-  Utilities:
-    get_grant         - Get grant information
-    get_folder_by_id  - Get folder details
-    current_time      - Get current time
-    epoch_to_datetime - Convert epoch to datetime
 
 For more information: https://developer.nylas.com/docs/dev-guide/mcp/`,
 		RunE: runServe,


### PR DESCRIPTION
**JIRA:** [TW-4778](https://nylas.atlassian.net/browse/TW-4778) | **Epic:** [TW-4638](https://nylas.atlassian.net/browse/TW-4638)

## Summary

Replaces the hardcoded static list of tools requiring `grant_id` injection with **dynamic discovery** from the upstream Nylas MCP server's `tools/list` response. This means when new tools are added to the Nylas MCP server, the proxy automatically picks them up — no CLI code changes needed.

## Problem

Previously, `toolsRequiringGrant` was a static map of 12 tool names. Every time a new tool was added upstream (e.g., contacts, folder CRUD), this list had to be manually updated in the CLI. Missing a tool meant `grant_id` wouldn't be injected, causing silent failures for users.

## Solution

### Dynamic Discovery
- When the proxy receives a `tools/list` response from upstream, it inspects each tool's `inputSchema.properties` for a `grant_id` field
- Discovered tools are cached in `p.grantTools` (thread-safe via `sync.RWMutex`)
- `toolRequiresGrant()` checks the dynamic set first, falling back to the static list only before the first `tools/list` response

### Expanded Fallback (12 → 32 tools)
- The static fallback now covers all known Nylas resources (calendars, events, messages, threads, folders, drafts, contacts, send operations)
- Minimizes the race window between proxy startup and first `tools/list` response
- Harmless if over-specified — dynamic discovery corrects it immediately

### Bug Fix: `confirm_send_draft`
- Live testing against the real Nylas MCP server revealed that `confirm_send_draft` has `grant_id` at the root level in its schema
- The old code incorrectly excluded it with a stale comment ("validates draft content only")
- Now correctly included in both fallback and dynamic discovery

## How It Works

```
AI Assistant ←→ [stdin/stdout] ←→ Nylas CLI Proxy ←→ [HTTPS] ←→ Nylas MCP Server
```

1. **Startup** — `grantTools` is `nil`, fallback list used
2. **First `tools/list` response** — proxy scans all tools for `grant_id` in schema, caches result
3. **Subsequent `tools/call`** — uses dynamic set to decide injection
4. **New tool added upstream** — automatically discovered on next `tools/list`, no CLI update needed

## Files Changed

| File | Change |
|------|--------|
| `proxy.go` | Add `grantTools` field, `toolRequiresGrant()` method, expand fallback list |
| `proxy_response.go` | Scan `tools/list` response for `grant_id` in tool schemas |
| `serve.go` | Update command description to reflect dynamic behavior |
| `proxy_e2e_test.go` | New: 4 E2E tests (22 sub-tests) with mock upstream server |
| `proxy_e2e_fixtures_test.go` | New: realistic mock `tools/list` and `initialize` responses |
| `proxy_forward_test.go` | Add test cases for contacts, delete_event, confirm_send_draft |
| `proxy_modify_test.go` | Add discovery test, expand fallback coverage test |

## E2E Test Coverage

Full proxy lifecycle tested against a mock upstream server:

| Scenario | Verified |
|----------|----------|
| `initialize` → timezone guidance appended | ✅ |
| `tools/list` → dynamic discovery populates grantTools | ✅ |
| `tools/list` → get_grant email made optional | ✅ |
| Grant tools (7) → grant_id auto-injected | ✅ |
| Utility tools (4) → grant_id NOT injected | ✅ |
| Explicit grant_id → NOT overridden | ✅ |
| `identifier` set → grant_id NOT injected | ✅ |
| `get_grant` without email → local keyring response | ✅ |
| `get_grant` with email → passes through to server | ✅ |
| Session ID → stored from server response | ✅ |
| Non-tools method → forwarded unchanged | ✅ |
| New upstream tool (not in fallback) → discovered dynamically | ✅ |
| No default grant configured → no injection, no crash | ✅ |
| Upstream 500 error → surfaced correctly | ✅ |

## Live Validation

Tested against the real Nylas MCP server — all 25 upstream tools correctly classified:
- 19 tools with `grant_id` → all discovered
- 6 tools without `grant_id` → all excluded
- Fallback covers 100% of upstream grant tools

## Security Review

- No hardcoded secrets, API keys, or tokens
- All test fixtures use synthetic data (`@example.com`, placeholder IDs)
- Mutex usage verified correct (RLock/Lock, copy-out pattern)
- No command injection, path traversal, or credential logging
- Upstream JSON parsed via `json.Unmarshal`, not string concatenation

## Test plan

- [x] `go test ./internal/adapters/mcp/... -v` — all 29 tests pass (including 22 new E2E sub-tests)
- [x] `go build ./cmd/nylas` — builds clean
- [x] `golangci-lint run ./internal/adapters/mcp/...` — no new lint issues
- [x] Live test: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | ./nylas mcp serve` — returns all 25 tools
- [x] Live test: tools/call for messages, calendars, contacts, events, folders, threads — all get grant_id injected
- [x] Live test: utility tools (current_time, epoch_to_datetime) — no grant_id injected

[TW-4778]: https://nylas.atlassian.net/browse/TW-4778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TW-4638]: https://nylas.atlassian.net/browse/TW-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ