### PR TITLE
TW-4947: Add Nylas Agent Account support and managed send parity

### DIFF
--- a/cmd/nylas/main.go
+++ b/cmd/nylas/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nylas/cli/internal/chat"
 	"github.com/nylas/cli/internal/cli"
 	"github.com/nylas/cli/internal/cli/admin"
+	"github.com/nylas/cli/internal/cli/agent"
 	"github.com/nylas/cli/internal/cli/ai"
 	"github.com/nylas/cli/internal/cli/audit"
 	"github.com/nylas/cli/internal/cli/auth"
@@ -40,6 +41,7 @@ func main() {
 	// Enable command typo suggestions (e.g., "Did you mean 'email'?")
 	rootCmd.SuggestionsMinimumDistance = 2
 	rootCmd.AddCommand(ai.NewAICmd())
+	rootCmd.AddCommand(agent.NewAgentCmd())
 	rootCmd.AddCommand(audit.NewAuditCmd())
 	rootCmd.AddCommand(auth.NewAuthCmd())
 	rootCmd.AddCommand(config.NewConfigCmd())

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -188,6 +188,7 @@ nylas email read <message-id> --decrypt                        # Decrypt PGP/MIM
 nylas email read <message-id> --verify                         # Verify GPG signature
 nylas email read <message-id> --decrypt --verify               # Decrypt and verify signature
 nylas email send --to EMAIL --subject SUBJECT --body BODY      # Send email
+nylas email send --to EMAIL --subject SUBJECT --body BODY --yes  # Skip confirmation
 nylas email send ... --sign                                    # Send GPG-signed email
 nylas email send ... --encrypt                                 # Send GPG-encrypted email
 nylas email send ... --sign --encrypt                          # Sign AND encrypt (recommended)
@@ -215,6 +216,11 @@ nylas email send --to EMAIL --subject S --body B --sign --encrypt  # Both (recom
 nylas email read <message-id> --decrypt                        # Decrypt encrypted email
 nylas email read <message-id> --decrypt --verify               # Decrypt + verify signature
 ```
+
+**Managed send behavior:**
+- Grants with provider `inbox` and `nylas` use the managed transactional send path automatically.
+- The sender address comes from the active grant email for those managed providers.
+- GPG signing/encryption and `--signature-id` are not supported for managed transactional sends.
 
 **AI features:**
 ```bash
@@ -438,6 +444,23 @@ nylas webhook server --port 8080 --tunnel cloudflared # With public tunnel
 ```
 
 **Details:** `docs/commands/webhooks.md`
+
+---
+
+## Agent Accounts
+
+Create and manage Nylas-managed agent accounts backed by provider `nylas`.
+
+```bash
+nylas agent list                               # List agent accounts
+nylas agent create <email>                     # Create agent account
+nylas agent create <email> --app-password PW   # Create account with IMAP/SMTP app password
+nylas agent delete <agent-id|email>            # Delete/revoke agent account
+nylas agent delete <agent-id|email> --yes      # Skip confirmation
+nylas agent status                             # Check connector + account status
+```
+
+**Details:** `docs/commands/agent.md`
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,6 +72,7 @@ Quick navigation guide to find the right documentation for your needs.
 - **Calendar** → [commands/calendar.md](commands/calendar.md)
 - **Contacts** → [commands/contacts.md](commands/contacts.md)
 - **Webhooks** → [commands/webhooks.md](commands/webhooks.md)
+- **Agent accounts** → [commands/agent.md](commands/agent.md)
 - **Inbound email** → [commands/inbound.md](commands/inbound.md)
 - **Scheduler** → [commands/scheduler.md](commands/scheduler.md)
 - **Admin** → [commands/admin.md](commands/admin.md)

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -1,0 +1,121 @@
+# Agent Accounts
+
+Manage Nylas agent accounts from the CLI.
+
+Agent accounts are managed email identities backed by provider `nylas`. Unlike OAuth grants, they do not require a third-party mailbox connection. The CLI keeps connector setup automatic and always uses `provider=nylas` for this command group.
+
+## Commands
+
+```bash
+nylas agent list
+nylas agent create <email>
+nylas agent create <email> --app-password <password>
+nylas agent delete <agent-id|email>
+nylas agent status
+```
+
+## List Agent Accounts
+
+```bash
+nylas agent list
+nylas agent list --json
+```
+
+**Example output:**
+```bash
+$ nylas agent list
+
+Agent Accounts (2)
+
+1. support@yourapp.nylas.email            active
+   ID: 11111111-1111-1111-1111-111111111111
+
+2. me@yourapp.nylas.email                 active
+   ID: 22222222-2222-2222-2222-222222222222
+```
+
+## Create Agent Account
+
+```bash
+nylas agent create me@yourapp.nylas.email
+nylas agent create me@yourapp.nylas.email --app-password 'ValidAgentPass123ABC!'
+nylas agent create support@yourapp.nylas.email --json
+```
+
+Behavior:
+- always creates a grant with `provider=nylas`
+- automatically creates the `nylas` connector first if it does not exist
+- stores the created grant locally like other authenticated accounts
+- optionally sets `settings.app_password` on the grant for IMAP/SMTP mail client access
+
+**Example output:**
+```bash
+$ nylas agent create me@yourapp.nylas.email
+
+✓ Agent account created successfully!
+
+Email:      me@yourapp.nylas.email
+Provider:   nylas
+Status:     valid
+```
+
+### `--app-password`
+
+Use `--app-password` when you want the agent account to work with a standard mail client over IMAP/SMTP submission.
+
+```bash
+nylas agent create me@yourapp.nylas.email --app-password 'ValidAgentPass123ABC!'
+```
+
+Requirements:
+- 18 to 40 characters
+- printable ASCII only, with no spaces
+- at least one uppercase letter
+- at least one lowercase letter
+- at least one digit
+
+When set, the agent account email becomes the mail-client username and the app password is used for IMAP/SMTP authentication.
+
+## Delete Agent Account
+
+```bash
+nylas agent delete 12345678-1234-1234-1234-123456789012
+nylas agent delete me@yourapp.nylas.email --yes
+```
+
+Deleting an agent account revokes the underlying `provider=nylas` grant.
+
+## Connector Status
+
+```bash
+nylas agent status
+nylas agent status --json
+```
+
+This reports:
+- whether the `nylas` connector is available
+- whether agent accounts already exist
+- which managed accounts are currently configured
+
+## Relationship to Inbound
+
+`nylas agent` and `nylas inbound` are different features:
+- `nylas agent` creates managed agent accounts backed by provider `nylas`
+- `nylas inbound` creates inbound inboxes backed by provider `inbox`
+
+Both can use `@yourapp.nylas.email` addresses, but they are separate command groups and separate provider types.
+
+Agent accounts can also expose the mailbox over IMAP and SMTP submission when an `app_password` is configured at creation time.
+
+## Sending Email from Agent Accounts
+
+When the active grant is an agent account (`provider=nylas`):
+- `nylas email send` automatically uses the managed transactional send path
+- the sender address is taken from the active grant email
+- GPG signing/encryption is not supported on that managed transactional path
+- stored signatures via `--signature-id` are not supported on that managed transactional path
+
+## See Also
+
+- [Email commands](email.md)
+- [Inbound email](inbound.md)

--- a/docs/commands/email.md
+++ b/docs/commands/email.md
@@ -107,6 +107,10 @@ nylas email send --template-id tpl_123 --template-data-file ./data.json --render
 # Send with a stored signature
 nylas email send --to "to@example.com" --subject "Subject" --body "Body" \
   --signature-id sig_123
+
+# Send from a managed agent account (provider=nylas)
+nylas auth switch <agent-grant-id>
+nylas email send --to "to@example.com" --subject "Hello" --body "Body" --yes
 ```
 
 **Tracking Options:**
@@ -124,6 +128,12 @@ nylas email send --to "to@example.com" --subject "Subject" --body "Body" \
 - `--render-only` - Preview the rendered hosted template without sending
 - `--template-strict` - Fail if the hosted template references missing variables (default: true)
 - `--signature-id` - Append a stored signature when sending, creating a draft, or sending a draft
+
+**Managed providers (`inbox`, `nylas`):**
+- `nylas email send` uses the managed transactional send path automatically
+- the sender address is taken from the active grant email
+- `--signature-id` is not supported for managed transactional sends
+- `--sign` and `--encrypt` are not supported for managed transactional sends
 
 **Example output (scheduled):**
 ```bash
@@ -187,6 +197,8 @@ nylas email send --list-gpg-keys
 ```
 
 `--signature-id` can't be combined with `--sign` or `--encrypt`, because stored signatures are only supported on the standard JSON send and draft endpoints.
+
+Managed transactional sends from `provider=inbox` or `provider=nylas` also do not support `--sign`, `--encrypt`, or `--signature-id`.
 
 ### Signatures
 

--- a/internal/adapters/keyring/grants.go
+++ b/internal/adapters/keyring/grants.go
@@ -24,6 +24,10 @@ func NewGrantStore(secrets ports.SecretStore) *GrantStore {
 
 // SaveGrant saves grant info to storage.
 func (g *GrantStore) SaveGrant(info domain.GrantInfo) error {
+	if info.ID == "" || info.Email == "" {
+		return domain.ErrInvalidInput
+	}
+
 	grants, err := g.ListGrants()
 	if err != nil && err != domain.ErrSecretNotFound {
 		return err
@@ -80,6 +84,9 @@ func (g *GrantStore) ListGrants() ([]domain.GrantInfo, error) {
 	data, err := g.secrets.Get(grantsKey)
 	if err != nil {
 		if err == domain.ErrSecretNotFound {
+			if err := g.repairDefaultGrant(nil); err != nil {
+				return nil, err
+			}
 			return []domain.GrantInfo{}, nil
 		}
 		return nil, err
@@ -89,7 +96,18 @@ func (g *GrantStore) ListGrants() ([]domain.GrantInfo, error) {
 	if err := json.Unmarshal([]byte(data), &grants); err != nil {
 		return nil, err
 	}
-	return grants, nil
+
+	sanitized, changed := sanitizeGrants(grants)
+	if changed {
+		if err := g.saveGrants(sanitized); err != nil {
+			return nil, err
+		}
+	}
+	if err := g.repairDefaultGrant(sanitized); err != nil {
+		return nil, err
+	}
+
+	return sanitized, nil
 }
 
 // DeleteGrant removes a grant from storage.
@@ -109,7 +127,11 @@ func (g *GrantStore) DeleteGrant(grantID string) error {
 	// Also delete the grant's token if it exists
 	_ = g.secrets.Delete(ports.GrantTokenKey(grantID))
 
-	return g.saveGrants(newGrants)
+	if err := g.saveGrants(newGrants); err != nil {
+		return err
+	}
+
+	return g.repairDefaultGrant(newGrants)
 }
 
 // SetDefaultGrant sets the default grant ID.
@@ -119,6 +141,11 @@ func (g *GrantStore) SetDefaultGrant(grantID string) error {
 
 // GetDefaultGrant returns the default grant ID.
 func (g *GrantStore) GetDefaultGrant() (string, error) {
+	_, err := g.ListGrants()
+	if err != nil {
+		return "", err
+	}
+
 	grantID, err := g.secrets.Get(defaultGrantKey)
 	if err != nil {
 		if err == domain.ErrSecretNotFound {
@@ -126,6 +153,7 @@ func (g *GrantStore) GetDefaultGrant() (string, error) {
 		}
 		return "", err
 	}
+
 	return grantID, nil
 }
 
@@ -142,4 +170,43 @@ func (g *GrantStore) saveGrants(grants []domain.GrantInfo) error {
 		return err
 	}
 	return g.secrets.Set(grantsKey, string(data))
+}
+
+func sanitizeGrants(grants []domain.GrantInfo) ([]domain.GrantInfo, bool) {
+	sanitized := make([]domain.GrantInfo, 0, len(grants))
+	changed := false
+	for _, grant := range grants {
+		if grant.ID == "" || grant.Email == "" {
+			changed = true
+			continue
+		}
+		sanitized = append(sanitized, grant)
+	}
+	return sanitized, changed
+}
+
+func (g *GrantStore) repairDefaultGrant(grants []domain.GrantInfo) error {
+	defaultID, err := g.secrets.Get(defaultGrantKey)
+	if err != nil {
+		if err != domain.ErrSecretNotFound {
+			return err
+		}
+		if len(grants) == 0 {
+			return nil
+		}
+		return g.secrets.Set(defaultGrantKey, grants[0].ID)
+	}
+
+	for _, grant := range grants {
+		if grant.ID == defaultID {
+			return nil
+		}
+	}
+
+	if len(grants) == 0 {
+		_ = g.secrets.Delete(defaultGrantKey)
+		return nil
+	}
+
+	return g.secrets.Set(defaultGrantKey, grants[0].ID)
 }

--- a/internal/adapters/keyring/keyring_test.go
+++ b/internal/adapters/keyring/keyring_test.go
@@ -409,8 +409,7 @@ func TestGrantStore_MultipleGrants(t *testing.T) {
 }
 
 // TestGrantStore_DefaultGrantBehavior tests the behavior of default grants
-// when grants are deleted. Note: DeleteGrant does NOT automatically clear
-// the default_grant key - that's the caller's responsibility (auth service).
+// when grants are deleted or local grant storage needs repair.
 func TestGrantStore_DefaultGrantBehavior(t *testing.T) {
 	secrets := keyring.NewMockSecretStore()
 	store := keyring.NewGrantStore(secrets)
@@ -421,28 +420,40 @@ func TestGrantStore_DefaultGrantBehavior(t *testing.T) {
 		Provider: domain.ProviderGoogle,
 	}
 
-	t.Run("delete default grant leaves stale reference", func(t *testing.T) {
-		// Save a grant and set it as default
+	grant2 := domain.GrantInfo{
+		ID:       "grant-2",
+		Email:    "user2@gmail.com",
+		Provider: domain.ProviderGoogle,
+	}
+
+	t.Run("delete default grant switches to another stored grant", func(t *testing.T) {
+		require.NoError(t, store.SaveGrant(grant1))
+		require.NoError(t, store.SaveGrant(grant2))
+		require.NoError(t, store.SetDefaultGrant(grant1.ID))
+
+		require.NoError(t, store.DeleteGrant(grant1.ID))
+
+		_, err := store.GetGrant(grant1.ID)
+		assert.ErrorIs(t, err, domain.ErrGrantNotFound)
+
+		defaultID, err := store.GetDefaultGrant()
+		require.NoError(t, err)
+		assert.Equal(t, "grant-2", defaultID)
+	})
+
+	t.Run("delete last remaining default grant clears default", func(t *testing.T) {
+		require.NoError(t, store.ClearGrants())
+
 		require.NoError(t, store.SaveGrant(grant1))
 		require.NoError(t, store.SetDefaultGrant(grant1.ID))
 
-		// Verify it's the default
-		defaultID, err := store.GetDefaultGrant()
-		require.NoError(t, err)
-		assert.Equal(t, "grant-1", defaultID)
-
-		// Delete the grant
 		require.NoError(t, store.DeleteGrant(grant1.ID))
 
-		// Verify grant is deleted
-		_, err = store.GetGrant(grant1.ID)
+		_, err := store.GetGrant(grant1.ID)
 		assert.ErrorIs(t, err, domain.ErrGrantNotFound)
 
-		// IMPORTANT: The default_grant key still contains the old ID
-		// This is by design - the caller (auth service) must handle this
-		defaultID, err = store.GetDefaultGrant()
-		require.NoError(t, err, "GetDefaultGrant should NOT return error - key still exists")
-		assert.Equal(t, "grant-1", defaultID, "Default still points to deleted grant")
+		_, err = store.GetDefaultGrant()
+		assert.ErrorIs(t, err, domain.ErrNoDefaultGrant)
 	})
 
 	t.Run("clear grants clears default", func(t *testing.T) {
@@ -456,5 +467,19 @@ func TestGrantStore_DefaultGrantBehavior(t *testing.T) {
 		// Now default should be cleared
 		_, err := store.GetDefaultGrant()
 		assert.ErrorIs(t, err, domain.ErrNoDefaultGrant)
+	})
+
+	t.Run("list grants repairs malformed local entries and stale default", func(t *testing.T) {
+		require.NoError(t, secrets.Set("grants", `[{"id":"","email":"","provider":"nylas"},{"id":"grant-2","email":"user2@gmail.com","provider":"google"}]`))
+		require.NoError(t, store.SetDefaultGrant("missing-grant"))
+
+		grants, err := store.ListGrants()
+		require.NoError(t, err)
+		require.Len(t, grants, 1)
+		assert.Equal(t, "grant-2", grants[0].ID)
+
+		defaultID, err := store.GetDefaultGrant()
+		require.NoError(t, err)
+		assert.Equal(t, "grant-2", defaultID)
 	})
 }

--- a/internal/adapters/nylas/agent.go
+++ b/internal/adapters/nylas/agent.go
@@ -1,0 +1,102 @@
+package nylas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+// ListAgentAccounts lists all managed agent accounts (grants with provider=nylas).
+func (c *HTTPClient) ListAgentAccounts(ctx context.Context) ([]domain.AgentAccount, error) {
+	grants, err := c.listManagedGrants(ctx, domain.ProviderNylas)
+	if err != nil {
+		return nil, err
+	}
+
+	accounts := make([]domain.AgentAccount, 0, len(grants))
+	for _, grant := range grants {
+		accounts = append(accounts, convertManagedGrantToAgentAccount(grant))
+	}
+
+	return accounts, nil
+}
+
+// GetAgentAccount retrieves a specific agent account by grant ID.
+func (c *HTTPClient) GetAgentAccount(ctx context.Context, grantID string) (*domain.AgentAccount, error) {
+	grant, err := c.getManagedGrant(ctx, grantID)
+	if err != nil {
+		return nil, err
+	}
+
+	if grant.Provider != domain.ProviderNylas {
+		return nil, fmt.Errorf("%w: grant is not a nylas agent account (provider=%s)", domain.ErrInvalidGrant, grant.Provider)
+	}
+
+	account := convertManagedGrantToAgentAccount(*grant)
+	return &account, nil
+}
+
+// CreateAgentAccount creates a new managed agent account grant.
+func (c *HTTPClient) CreateAgentAccount(ctx context.Context, email, appPassword string) (*domain.AgentAccount, error) {
+	queryURL := fmt.Sprintf("%s/v3/connect/custom", c.baseURL)
+
+	settings := map[string]any{
+		"email": email,
+	}
+	if appPassword != "" {
+		settings["app_password"] = appPassword
+	}
+
+	payload := map[string]any{
+		"provider": string(domain.ProviderNylas),
+		"settings": settings,
+	}
+
+	resp, err := c.doJSONRequest(ctx, "POST", queryURL, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	grant, err := decodeCreatedManagedGrant(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	account := convertManagedGrantToAgentAccount(*grant)
+	return &account, nil
+}
+
+// DeleteAgentAccount deletes an agent account by revoking its grant.
+func (c *HTTPClient) DeleteAgentAccount(ctx context.Context, grantID string) error {
+	return c.deleteManagedGrant(ctx, grantID, domain.ProviderNylas)
+}
+
+func decodeCreatedManagedGrant(resp *http.Response) (*managedGrantResponse, error) {
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var wrapped struct {
+		Data managedGrantResponse `json:"data"`
+	}
+	if err := json.Unmarshal(body, &wrapped); err == nil && wrapped.Data.ID != "" {
+		return &wrapped.Data, nil
+	}
+
+	var grant managedGrantResponse
+	if err := json.Unmarshal(body, &grant); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	if grant.ID == "" {
+		return nil, fmt.Errorf("failed to decode response: missing grant id")
+	}
+
+	return &grant, nil
+}

--- a/internal/adapters/nylas/agent_test.go
+++ b/internal/adapters/nylas/agent_test.go
@@ -1,0 +1,197 @@
+//go:build !integration
+// +build !integration
+
+package nylas
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAgentAccounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v3/grants", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "nylas", r.URL.Query().Get("provider"))
+
+		response := map[string]any{
+			"data": []map[string]any{
+				{
+					"id":            "agent-001",
+					"email":         "agent@example.com",
+					"provider":      "nylas",
+					"grant_status":  "valid",
+					"credential_id": "cred-123",
+					"settings": map[string]any{
+						"policy_id": "policy-123",
+					},
+					"created_at": time.Now().Unix(),
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.baseURL = server.URL
+	client.SetCredentials("", "", "test-api-key")
+
+	accounts, err := client.ListAgentAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+	assert.Equal(t, "agent-001", accounts[0].ID)
+	assert.Equal(t, "agent@example.com", accounts[0].Email)
+	assert.Equal(t, "policy-123", accounts[0].Settings.PolicyID)
+}
+
+func TestListAgentAccounts_PaginatesAllResults(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v3/grants", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "nylas", r.URL.Query().Get("provider"))
+
+		requests++
+		var response map[string]any
+		if r.URL.Query().Get("page_token") == "" {
+			response = map[string]any{
+				"data": []map[string]any{
+					{
+						"id":           "agent-001",
+						"email":        "first@example.com",
+						"provider":     "nylas",
+						"grant_status": "valid",
+					},
+				},
+				"next_cursor": "cursor-2",
+			}
+		} else {
+			assert.Equal(t, "cursor-2", r.URL.Query().Get("page_token"))
+			response = map[string]any{
+				"data": []map[string]any{
+					{
+						"id":           "agent-002",
+						"email":        "second@example.com",
+						"provider":     "nylas",
+						"grant_status": "valid",
+					},
+				},
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.baseURL = server.URL
+	client.SetCredentials("", "", "test-api-key")
+
+	accounts, err := client.ListAgentAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, accounts, 2)
+	assert.Equal(t, 2, requests)
+	assert.Equal(t, "agent-001", accounts[0].ID)
+	assert.Equal(t, "agent-002", accounts[1].ID)
+}
+
+func TestCreateAgentAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v3/connect/custom", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var payload map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.Equal(t, "nylas", payload["provider"])
+
+		settings, ok := payload["settings"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "agent@example.com", settings["email"])
+		assert.Equal(t, "ValidAgentPass123ABC!", settings["app_password"])
+
+		response := map[string]any{
+			"data": map[string]any{
+				"id":           "agent-new",
+				"email":        "agent@example.com",
+				"provider":     "nylas",
+				"grant_status": "valid",
+				"created_at":   time.Now().Unix(),
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.baseURL = server.URL
+	client.SetCredentials("", "", "test-api-key")
+
+	account, err := client.CreateAgentAccount(context.Background(), "agent@example.com", "ValidAgentPass123ABC!")
+	require.NoError(t, err)
+	assert.Equal(t, "agent-new", account.ID)
+	assert.Equal(t, "agent@example.com", account.Email)
+}
+
+func TestCreateAgentAccount_DirectResponseFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]any{
+			"id":           "agent-direct",
+			"email":        "agent@example.com",
+			"provider":     "nylas",
+			"grant_status": "valid",
+			"created_at":   time.Now().Unix(),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.baseURL = server.URL
+	client.SetCredentials("", "", "test-api-key")
+
+	account, err := client.CreateAgentAccount(context.Background(), "agent@example.com", "")
+	require.NoError(t, err)
+	assert.Equal(t, "agent-direct", account.ID)
+	assert.Equal(t, "agent@example.com", account.Email)
+}
+
+func TestGetAgentAccountRejectsNonNylasProvider(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]any{
+			"data": map[string]any{
+				"id":           "grant-001",
+				"email":        "user@gmail.com",
+				"provider":     "google",
+				"grant_status": "valid",
+				"created_at":   time.Now().Unix(),
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.baseURL = server.URL
+	client.SetCredentials("", "", "test-api-key")
+
+	_, err := client.GetAgentAccount(context.Background(), "grant-001")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a nylas agent account")
+}

--- a/internal/adapters/nylas/demo_agent.go
+++ b/internal/adapters/nylas/demo_agent.go
@@ -1,0 +1,40 @@
+package nylas
+
+import (
+	"context"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+func (d *DemoClient) ListAgentAccounts(ctx context.Context) ([]domain.AgentAccount, error) {
+	return []domain.AgentAccount{
+		{
+			ID:          "agent-demo-1",
+			Provider:    domain.ProviderNylas,
+			Email:       "demo-agent@example.com",
+			GrantStatus: "valid",
+		},
+	}, nil
+}
+
+func (d *DemoClient) GetAgentAccount(ctx context.Context, grantID string) (*domain.AgentAccount, error) {
+	return &domain.AgentAccount{
+		ID:          grantID,
+		Provider:    domain.ProviderNylas,
+		Email:       "demo-agent@example.com",
+		GrantStatus: "valid",
+	}, nil
+}
+
+func (d *DemoClient) CreateAgentAccount(ctx context.Context, email, appPassword string) (*domain.AgentAccount, error) {
+	return &domain.AgentAccount{
+		ID:          "agent-demo-new",
+		Provider:    domain.ProviderNylas,
+		Email:       email,
+		GrantStatus: "valid",
+	}, nil
+}
+
+func (d *DemoClient) DeleteAgentAccount(ctx context.Context, grantID string) error {
+	return nil
+}

--- a/internal/adapters/nylas/inbound.go
+++ b/internal/adapters/nylas/inbound.go
@@ -9,36 +9,14 @@ import (
 
 // ListInboundInboxes lists all inbound inboxes (grants with provider=inbox).
 func (c *HTTPClient) ListInboundInboxes(ctx context.Context) ([]domain.InboundInbox, error) {
-	// Get all grants and filter by provider=inbox
-	baseURL := fmt.Sprintf("%s/v3/grants", c.baseURL)
-	queryURL := NewQueryBuilder().Add("provider", "inbox").BuildURL(baseURL)
-
-	var result struct {
-		Data []struct {
-			ID          string          `json:"id"`
-			Email       string          `json:"email"`
-			Provider    string          `json:"provider"`
-			GrantStatus string          `json:"grant_status"`
-			CreatedAt   domain.UnixTime `json:"created_at"`
-			UpdatedAt   domain.UnixTime `json:"updated_at"`
-		} `json:"data"`
-	}
-	if err := c.doGet(ctx, queryURL, &result); err != nil {
+	grants, err := c.listManagedGrants(ctx, domain.ProviderInbox)
+	if err != nil {
 		return nil, err
 	}
 
-	inboxes := make([]domain.InboundInbox, 0, len(result.Data))
-	for _, g := range result.Data {
-		// Only include inboxes with provider=inbox
-		if g.Provider == "inbox" {
-			inboxes = append(inboxes, domain.InboundInbox{
-				ID:          g.ID,
-				Email:       g.Email,
-				GrantStatus: g.GrantStatus,
-				CreatedAt:   g.CreatedAt,
-				UpdatedAt:   g.UpdatedAt,
-			})
-		}
+	inboxes := make([]domain.InboundInbox, 0, len(grants))
+	for _, grant := range grants {
+		inboxes = append(inboxes, convertManagedGrantToInboundInbox(grant))
 	}
 
 	return inboxes, nil
@@ -46,90 +24,34 @@ func (c *HTTPClient) ListInboundInboxes(ctx context.Context) ([]domain.InboundIn
 
 // GetInboundInbox retrieves a specific inbound inbox by grant ID.
 func (c *HTTPClient) GetInboundInbox(ctx context.Context, grantID string) (*domain.InboundInbox, error) {
-	queryURL := fmt.Sprintf("%s/v3/grants/%s", c.baseURL, grantID)
-
-	var result struct {
-		Data struct {
-			ID          string          `json:"id"`
-			Email       string          `json:"email"`
-			Provider    string          `json:"provider"`
-			GrantStatus string          `json:"grant_status"`
-			CreatedAt   domain.UnixTime `json:"created_at"`
-			UpdatedAt   domain.UnixTime `json:"updated_at"`
-		} `json:"data"`
-	}
-	if err := c.doGetWithNotFound(ctx, queryURL, &result, domain.ErrGrantNotFound); err != nil {
+	grant, err := c.getManagedGrant(ctx, grantID)
+	if err != nil {
 		return nil, err
 	}
 
-	// Verify it's an inbox provider
-	if result.Data.Provider != "inbox" {
-		return nil, fmt.Errorf("%w: grant is not an inbound inbox (provider=%s)", domain.ErrInvalidGrant, result.Data.Provider)
+	if grant.Provider != domain.ProviderInbox {
+		return nil, fmt.Errorf("%w: grant is not an inbound inbox (provider=%s)", domain.ErrInvalidGrant, grant.Provider)
 	}
 
-	return &domain.InboundInbox{
-		ID:          result.Data.ID,
-		Email:       result.Data.Email,
-		GrantStatus: result.Data.GrantStatus,
-		CreatedAt:   result.Data.CreatedAt,
-		UpdatedAt:   result.Data.UpdatedAt,
-	}, nil
+	inbox := convertManagedGrantToInboundInbox(*grant)
+	return &inbox, nil
 }
 
 // CreateInboundInbox creates a new inbound inbox with the given email address.
 // The email parameter is the local part (e.g., "support" for support@app.nylas.email).
 func (c *HTTPClient) CreateInboundInbox(ctx context.Context, email string) (*domain.InboundInbox, error) {
-	queryURL := fmt.Sprintf("%s/v3/grants", c.baseURL)
-
-	// Create the request payload for custom auth with inbox provider
-	payload := map[string]any{
-		"provider": "inbox",
-		"settings": map[string]string{
-			"email": email,
-		},
-	}
-
-	resp, err := c.doJSONRequest(ctx, "POST", queryURL, payload)
+	grant, err := c.createManagedGrant(ctx, domain.ProviderInbox, email)
 	if err != nil {
 		return nil, err
 	}
 
-	var result struct {
-		Data struct {
-			ID          string          `json:"id"`
-			Email       string          `json:"email"`
-			Provider    string          `json:"provider"`
-			GrantStatus string          `json:"grant_status"`
-			CreatedAt   domain.UnixTime `json:"created_at"`
-			UpdatedAt   domain.UnixTime `json:"updated_at"`
-		} `json:"data"`
-	}
-	if err := c.decodeJSONResponse(resp, &result); err != nil {
-		return nil, err
-	}
-
-	return &domain.InboundInbox{
-		ID:          result.Data.ID,
-		Email:       result.Data.Email,
-		GrantStatus: result.Data.GrantStatus,
-		CreatedAt:   result.Data.CreatedAt,
-		UpdatedAt:   result.Data.UpdatedAt,
-	}, nil
+	inbox := convertManagedGrantToInboundInbox(*grant)
+	return &inbox, nil
 }
 
 // DeleteInboundInbox deletes an inbound inbox by revoking its grant.
 func (c *HTTPClient) DeleteInboundInbox(ctx context.Context, grantID string) error {
-	// First verify it's an inbox provider
-	inbox, err := c.GetInboundInbox(ctx, grantID)
-	if err != nil {
-		return err
-	}
-	if inbox == nil {
-		return domain.ErrGrantNotFound
-	}
-
-	// Use RevokeGrant to delete the inbox
-	return c.RevokeGrant(ctx, grantID)
+	return c.deleteManagedGrant(ctx, grantID, domain.ProviderInbox)
 }
 
 // GetInboundMessages retrieves messages for an inbound inbox.

--- a/internal/adapters/nylas/integration_grants_test.go
+++ b/internal/adapters/nylas/integration_grants_test.go
@@ -49,6 +49,7 @@ func TestIntegration_ListGrants_ValidatesProvider(t *testing.T) {
 		"icloud":           true,
 		"ews":              true,
 		"inbox":            true, // Nylas Native Auth
+		"nylas":            true, // Nylas-managed agent account provider
 		"virtual":          true,
 		"virtual-calendar": true, // Virtual calendar provider
 	}

--- a/internal/adapters/nylas/managed_grants.go
+++ b/internal/adapters/nylas/managed_grants.go
@@ -1,0 +1,140 @@
+package nylas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+type managedGrantResponse struct {
+	ID           string               `json:"id"`
+	Email        string               `json:"email"`
+	Provider     domain.Provider      `json:"provider"`
+	GrantStatus  string               `json:"grant_status"`
+	CreatedAt    domain.UnixTime      `json:"created_at"`
+	UpdatedAt    domain.UnixTime      `json:"updated_at"`
+	CredentialID string               `json:"credential_id,omitempty"`
+	Blocked      bool                 `json:"blocked,omitempty"`
+	Settings     agentSettingsPayload `json:"settings,omitempty"`
+}
+
+type agentSettingsPayload struct {
+	PolicyID string `json:"policy_id,omitempty"`
+}
+
+func (c *HTTPClient) listManagedGrants(ctx context.Context, provider domain.Provider) ([]managedGrantResponse, error) {
+	baseURL := fmt.Sprintf("%s/v3/grants", c.baseURL)
+	pageToken := ""
+	grants := make([]managedGrantResponse, 0)
+
+	for {
+		queryURL := NewQueryBuilder().
+			Add("provider", string(provider)).
+			Add("page_token", pageToken).
+			BuildURL(baseURL)
+
+		var result struct {
+			Data       []managedGrantResponse `json:"data"`
+			NextCursor string                 `json:"next_cursor,omitempty"`
+		}
+		if err := c.doGet(ctx, queryURL, &result); err != nil {
+			return nil, err
+		}
+
+		for _, grant := range result.Data {
+			if grant.Provider == provider {
+				grants = append(grants, grant)
+			}
+		}
+
+		if result.NextCursor == "" {
+			break
+		}
+		if result.NextCursor == pageToken {
+			return nil, fmt.Errorf("failed to paginate managed grants: repeated cursor %q", result.NextCursor)
+		}
+		pageToken = result.NextCursor
+	}
+
+	return grants, nil
+}
+
+func (c *HTTPClient) getManagedGrant(ctx context.Context, grantID string) (*managedGrantResponse, error) {
+	queryURL := fmt.Sprintf("%s/v3/grants/%s", c.baseURL, grantID)
+
+	var result struct {
+		Data managedGrantResponse `json:"data"`
+	}
+	if err := c.doGetWithNotFound(ctx, queryURL, &result, domain.ErrGrantNotFound); err != nil {
+		return nil, err
+	}
+
+	return &result.Data, nil
+}
+
+func (c *HTTPClient) createManagedGrant(ctx context.Context, provider domain.Provider, email string) (*managedGrantResponse, error) {
+	queryURL := fmt.Sprintf("%s/v3/grants", c.baseURL)
+
+	payload := map[string]any{
+		"provider": string(provider),
+		"settings": map[string]string{
+			"email": email,
+		},
+	}
+
+	resp, err := c.doJSONRequest(ctx, "POST", queryURL, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Data managedGrantResponse `json:"data"`
+	}
+	if err := c.decodeJSONResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Data, nil
+}
+
+func (c *HTTPClient) deleteManagedGrant(ctx context.Context, grantID string, expectedProvider domain.Provider) error {
+	grant, err := c.getManagedGrant(ctx, grantID)
+	if err != nil {
+		return err
+	}
+	if grant == nil {
+		return domain.ErrGrantNotFound
+	}
+	if grant.Provider != expectedProvider {
+		return fmt.Errorf("%w: grant is not a %s managed grant (provider=%s)", domain.ErrInvalidGrant, expectedProvider, grant.Provider)
+	}
+
+	return c.RevokeGrant(ctx, grantID)
+}
+
+func convertManagedGrantToInboundInbox(grant managedGrantResponse) domain.InboundInbox {
+	return domain.InboundInbox{
+		ID:          grant.ID,
+		Email:       grant.Email,
+		GrantStatus: grant.GrantStatus,
+		CreatedAt:   grant.CreatedAt,
+		UpdatedAt:   grant.UpdatedAt,
+	}
+}
+
+func convertManagedGrantToAgentAccount(grant managedGrantResponse) domain.AgentAccount {
+	return domain.AgentAccount{
+		ID:           grant.ID,
+		Provider:     grant.Provider,
+		Email:        grant.Email,
+		GrantStatus:  grant.GrantStatus,
+		CreatedAt:    grant.CreatedAt,
+		UpdatedAt:    grant.UpdatedAt,
+		CredentialID: grant.CredentialID,
+		Blocked:      grant.Blocked,
+		Settings: domain.AgentAccountSettings{
+			PolicyID: grant.Settings.PolicyID,
+		},
+	}
+}

--- a/internal/adapters/nylas/mock_agent.go
+++ b/internal/adapters/nylas/mock_agent.go
@@ -1,0 +1,40 @@
+package nylas
+
+import (
+	"context"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+func (m *MockClient) ListAgentAccounts(ctx context.Context) ([]domain.AgentAccount, error) {
+	return []domain.AgentAccount{
+		{
+			ID:          "agent-1",
+			Provider:    domain.ProviderNylas,
+			Email:       "agent@example.com",
+			GrantStatus: "valid",
+		},
+	}, nil
+}
+
+func (m *MockClient) GetAgentAccount(ctx context.Context, grantID string) (*domain.AgentAccount, error) {
+	return &domain.AgentAccount{
+		ID:          grantID,
+		Provider:    domain.ProviderNylas,
+		Email:       "agent@example.com",
+		GrantStatus: "valid",
+	}, nil
+}
+
+func (m *MockClient) CreateAgentAccount(ctx context.Context, email, appPassword string) (*domain.AgentAccount, error) {
+	return &domain.AgentAccount{
+		ID:          "agent-new",
+		Provider:    domain.ProviderNylas,
+		Email:       email,
+		GrantStatus: "valid",
+	}, nil
+}
+
+func (m *MockClient) DeleteAgentAccount(ctx context.Context, grantID string) error {
+	return nil
+}

--- a/internal/adapters/nylas/transactional.go
+++ b/internal/adapters/nylas/transactional.go
@@ -8,12 +8,25 @@ import (
 	"github.com/nylas/cli/internal/domain"
 )
 
+func buildTransactionalSendPayload(req *domain.SendMessageRequest) map[string]any {
+	payload := buildSendMessagePayload(req, false)
+
+	if len(req.From) > 0 {
+		payload["from"] = map[string]string{
+			"name":  req.From[0].Name,
+			"email": req.From[0].Email,
+		}
+	}
+
+	return payload
+}
+
 // SendTransactionalMessage sends an email via the domain-based transactional endpoint.
 // Used for Inbox provider grants: POST /v3/domains/{domain}/messages/send
 func (c *HTTPClient) SendTransactionalMessage(ctx context.Context, domainName string, req *domain.SendMessageRequest) (*domain.Message, error) {
 	queryURL := fmt.Sprintf("%s/v3/domains/%s/messages/send", c.baseURL, domainName)
 
-	resp, err := c.doJSONRequest(ctx, "POST", queryURL, buildSendMessagePayload(req, false), http.StatusOK, http.StatusCreated, http.StatusAccepted)
+	resp, err := c.doJSONRequest(ctx, "POST", queryURL, buildTransactionalSendPayload(req), http.StatusOK, http.StatusCreated, http.StatusAccepted)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/nylas/transactional_test.go
+++ b/internal/adapters/nylas/transactional_test.go
@@ -114,6 +114,11 @@ func TestHTTPClient_SendTransactionalMessage(t *testing.T) {
 				for _, field := range tt.expectedFields {
 					assert.Contains(t, body, field, "Missing field: %s", field)
 				}
+				if from, ok := body["from"]; ok {
+					fromMap, ok := from.(map[string]any)
+					require.True(t, ok, "transactional from must be an object")
+					assert.Equal(t, tt.request.From[0].Email, fromMap["email"])
+				}
 
 				response := map[string]any{
 					"data": map[string]any{

--- a/internal/cli/agent/agent.go
+++ b/internal/cli/agent/agent.go
@@ -1,0 +1,37 @@
+package agent
+
+import "github.com/spf13/cobra"
+
+// NewAgentCmd creates the agent command group.
+func NewAgentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "agent",
+		Aliases: []string{"agents"},
+		Short:   "Manage Nylas agent accounts",
+		Long: `Manage Nylas agent accounts.
+
+Agent accounts are managed email identities backed by the Nylas provider.
+This command always uses provider=nylas and keeps the connector setup out of
+the user's path.
+
+Examples:
+  # Create a new agent account
+  nylas agent create me@yourapp.nylas.email
+
+  # List agent accounts
+  nylas agent list
+
+  # Check connector and account status
+  nylas agent status
+
+  # Delete an agent account
+  nylas agent delete <agent-id>`,
+	}
+
+	cmd.AddCommand(newCreateCmd())
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newDeleteCmd())
+	cmd.AddCommand(newStatusCmd())
+
+	return cmd
+}

--- a/internal/cli/agent/agent_test.go
+++ b/internal/cli/agent/agent_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/nylas/cli/internal/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAgentCmd(t *testing.T) {
+	cmd := NewAgentCmd()
+
+	assert.Equal(t, "agent", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "agents")
+	assert.Contains(t, cmd.Short, "agent")
+	assert.Contains(t, cmd.Long, "provider=nylas")
+
+	expected := []string{"create", "list", "delete", "status"}
+	cmdMap := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		cmdMap[sub.Name()] = true
+	}
+	for _, name := range expected {
+		assert.True(t, cmdMap[name], "missing subcommand %s", name)
+	}
+}
+
+func TestCreateCmd(t *testing.T) {
+	cmd := newCreateCmd()
+
+	assert.Equal(t, "create <email>", cmd.Use)
+	assert.NotNil(t, cmd.Flags().Lookup("json"))
+	assert.NotNil(t, cmd.Flags().Lookup("app-password"))
+	assert.Contains(t, cmd.Long, "provider=nylas")
+}
+
+func TestValidateAgentAppPassword(t *testing.T) {
+	assert.NoError(t, validateAgentAppPassword(""))
+	assert.NoError(t, validateAgentAppPassword("ValidAgentPass123ABC!"))
+
+	assert.EqualError(t, validateAgentAppPassword("short"), "app password must be between 18 and 40 characters")
+	assert.EqualError(t, validateAgentAppPassword("Invalid Agent Pass123"), "app password must use printable ASCII characters only and cannot contain spaces")
+	assert.EqualError(t, validateAgentAppPassword("alllowercasepassword123"), "app password must include at least one uppercase letter, one lowercase letter, and one digit")
+}
+
+func TestDeleteCmd(t *testing.T) {
+	cmd := newDeleteCmd()
+
+	assert.Equal(t, "delete <agent-id|email>", cmd.Use)
+	assert.NotNil(t, cmd.Flags().Lookup("yes"))
+	assert.NotNil(t, cmd.Flags().Lookup("force"))
+}
+
+func TestIsDeleteConfirmed(t *testing.T) {
+	assert.True(t, isDeleteConfirmed("y\n"))
+	assert.True(t, isDeleteConfirmed("yes\n"))
+	assert.True(t, isDeleteConfirmed("delete\n"))
+	assert.False(t, isDeleteConfirmed("n\n"))
+	assert.False(t, isDeleteConfirmed("\n"))
+}
+
+func TestFindNylasConnector(t *testing.T) {
+	connectors := []domain.Connector{
+		{Provider: "google", ID: "conn-google"},
+		{Provider: "nylas"},
+	}
+
+	connector := findNylasConnector(connectors)
+	assert.NotNil(t, connector)
+	assert.Equal(t, "nylas", connector.Provider)
+	assert.Empty(t, connector.ID)
+	assert.Nil(t, findNylasConnector([]domain.Connector{{Provider: "google"}}))
+}
+
+func TestFormatConnectorSummary(t *testing.T) {
+	assert.Equal(t, "nylas", formatConnectorSummary(domain.Connector{Provider: "nylas"}))
+	assert.Equal(t, "nylas (conn-nylas)", formatConnectorSummary(domain.Connector{
+		Provider: "nylas",
+		ID:       "conn-nylas",
+	}))
+}

--- a/internal/cli/agent/create.go
+++ b/internal/cli/agent/create.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+func newCreateCmd() *cobra.Command {
+	var jsonOutput bool
+	var appPassword string
+
+	cmd := &cobra.Command{
+		Use:   "create <email>",
+		Short: "Create a new agent account",
+		Long: `Create a new Nylas agent account.
+
+This command always creates a provider=nylas grant. If the nylas connector
+does not exist yet, it will be created automatically first.
+
+Examples:
+  nylas agent create me@yourapp.nylas.email
+  nylas agent create support@yourapp.nylas.email --json
+  nylas agent create debug@yourapp.nylas.email --app-password 'ValidAgentPass123ABC!'`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(args[0], appPassword, jsonOutput)
+		},
+	}
+
+	cmd.Flags().StringVar(&appPassword, "app-password", "", "Optional IMAP/SMTP app password for mail-client access")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+
+	return cmd
+}
+
+func runCreate(email, appPassword string, jsonOutput bool) error {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		printError("Email address cannot be empty")
+		return common.NewInputError("email address cannot be empty")
+	}
+	if strings.Contains(email, " ") {
+		printError("Email address should not contain spaces")
+		return common.NewInputError("invalid email address - should not contain spaces")
+	}
+	if err := validateAgentAppPassword(appPassword); err != nil {
+		printError(err.Error())
+		return err
+	}
+
+	_, err := common.WithClientNoGrant(func(ctx context.Context, client ports.NylasClient) (struct{}, error) {
+		connector, err := ensureNylasConnector(ctx, client)
+		if err != nil {
+			return struct{}{}, common.WrapCreateError("nylas connector", err)
+		}
+
+		account, err := client.CreateAgentAccount(ctx, email, appPassword)
+		if err != nil {
+			return struct{}{}, common.WrapCreateError("agent account", err)
+		}
+
+		saveGrantLocally(account.ID, account.Email)
+
+		if jsonOutput {
+			data, _ := json.MarshalIndent(account, "", "  ")
+			fmt.Println(string(data))
+			return struct{}{}, nil
+		}
+
+		printSuccess("Agent account created successfully!")
+		fmt.Println()
+		printAgentDetails(*account)
+		if connector != nil {
+			_, _ = common.Dim.Printf("Connector: %s\n", formatConnectorSummary(*connector))
+		}
+
+		fmt.Println()
+		_, _ = common.Dim.Println("Next steps:")
+		_, _ = common.Dim.Printf("  1. List agent accounts: nylas agent list\n")
+		_, _ = common.Dim.Printf("  2. Check connector status: nylas agent status\n")
+		_, _ = common.Dim.Printf("  3. Delete this account: nylas agent delete %s\n", account.ID)
+
+		return struct{}{}, nil
+	})
+
+	return err
+}
+
+func validateAgentAppPassword(appPassword string) error {
+	if appPassword == "" {
+		return nil
+	}
+	if len(appPassword) < 18 || len(appPassword) > 40 {
+		return common.NewInputError("app password must be between 18 and 40 characters")
+	}
+
+	var hasUpper, hasLower, hasDigit bool
+	for _, r := range appPassword {
+		if r < 33 || r > 126 {
+			return common.NewInputError("app password must use printable ASCII characters only and cannot contain spaces")
+		}
+		switch {
+		case 'A' <= r && r <= 'Z':
+			hasUpper = true
+		case 'a' <= r && r <= 'z':
+			hasLower = true
+		case '0' <= r && r <= '9':
+			hasDigit = true
+		}
+	}
+
+	if !hasUpper || !hasLower || !hasDigit {
+		return common.NewInputError("app password must include at least one uppercase letter, one lowercase letter, and one digit")
+	}
+
+	return nil
+}
+
+func formatConnectorSummary(connector domain.Connector) string {
+	if connector.ID == "" {
+		return connector.Provider
+	}
+	return fmt.Sprintf("%s (%s)", connector.Provider, connector.ID)
+}

--- a/internal/cli/agent/delete.go
+++ b/internal/cli/agent/delete.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+func newDeleteCmd() *cobra.Command {
+	var (
+		force bool
+		yes   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <agent-id|email>",
+		Short: "Delete an agent account",
+		Long: `Delete a Nylas agent account.
+
+This permanently revokes the provider=nylas grant.
+
+Examples:
+  nylas agent delete 123456
+  nylas agent delete me@yourapp.nylas.email --yes`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			identifier, err := getAgentIdentifier(args)
+			if err != nil {
+				return err
+			}
+
+			client, err := common.GetNylasClient()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := common.CreateContext()
+			grantID, err := resolveAgentID(ctx, client, identifier)
+			cancel()
+			if err != nil {
+				return common.WrapGetError("agent account", err)
+			}
+
+			ctx2, cancel2 := common.CreateContext()
+			account, err := client.GetAgentAccount(ctx2, grantID)
+			cancel2()
+			if err != nil {
+				return common.WrapGetError("agent account", err)
+			}
+
+			if !yes && !force {
+				fmt.Printf("You are about to delete the agent account:\n")
+				fmt.Printf("  Email: %s\n", common.Cyan.Sprint(account.Email))
+				fmt.Printf("  ID:    %s\n", account.ID)
+				fmt.Println()
+				_, _ = common.Yellow.Println("This action cannot be undone.")
+				fmt.Println()
+
+				fmt.Print("Are you sure? [y/N]: ")
+				reader := bufio.NewReader(os.Stdin)
+				input, _ := reader.ReadString('\n')
+				if !isDeleteConfirmed(input) {
+					fmt.Println("Deletion cancelled.")
+					return nil
+				}
+			}
+
+			ctx3, cancel3 := common.CreateContext()
+			defer cancel3()
+
+			err = common.RunWithSpinner("Deleting agent account...", func() error {
+				return client.DeleteAgentAccount(ctx3, grantID)
+			})
+			if err != nil {
+				return common.WrapDeleteError("agent account", err)
+			}
+
+			removeGrantLocally(grantID)
+			printSuccess("Agent account %s deleted successfully!", account.Email)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force delete without confirmation (alias for --yes)")
+
+	return cmd
+}
+
+func isDeleteConfirmed(input string) bool {
+	switch strings.ToLower(strings.TrimSpace(input)) {
+	case "y", "yes", "delete":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/agent/helpers.go
+++ b/internal/cli/agent/helpers.go
@@ -1,0 +1,130 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/ports"
+)
+
+func printError(format string, args ...any) {
+	common.PrintError(format, args...)
+}
+
+func printSuccess(format string, args ...any) {
+	common.PrintSuccess(format, args...)
+}
+
+func formatStatus(status string) string {
+	return common.FormatGrantStatus(status)
+}
+
+func printAgentSummary(account domain.AgentAccount, index int) {
+	createdStr := common.FormatTimeAgo(account.CreatedAt.Time)
+	fmt.Printf("%d. %-40s %s  %s\n",
+		index+1,
+		common.Cyan.Sprint(account.Email),
+		common.Dim.Sprint(createdStr),
+		formatStatus(account.GrantStatus),
+	)
+	_, _ = common.Dim.Printf("   ID: %s\n", account.ID)
+}
+
+func printAgentDetails(account domain.AgentAccount) {
+	fmt.Println(strings.Repeat("─", 60))
+	_, _ = common.BoldWhite.Printf("Agent Account: %s\n", account.Email)
+	fmt.Println(strings.Repeat("─", 60))
+	fmt.Printf("ID:           %s\n", account.ID)
+	fmt.Printf("Provider:     %s\n", account.Provider.DisplayName())
+	fmt.Printf("Email:        %s\n", account.Email)
+	fmt.Printf("Status:       %s\n", formatStatus(account.GrantStatus))
+	if account.CredentialID != "" {
+		fmt.Printf("Credential:   %s\n", account.CredentialID)
+	}
+	if account.Settings.PolicyID != "" {
+		fmt.Printf("Policy ID:    %s\n", account.Settings.PolicyID)
+	}
+	fmt.Printf("Blocked:      %t\n", account.Blocked)
+	if !account.CreatedAt.IsZero() {
+		fmt.Printf("Created:      %s (%s)\n", account.CreatedAt.Format(common.DisplayDateTime), common.FormatTimeAgo(account.CreatedAt.Time))
+	}
+	if !account.UpdatedAt.IsZero() {
+		fmt.Printf("Updated:      %s (%s)\n", account.UpdatedAt.Format(common.DisplayDateTime), common.FormatTimeAgo(account.UpdatedAt.Time))
+	}
+	fmt.Println()
+}
+
+func saveGrantLocally(grantID, email string) {
+	common.SaveGrantLocally(grantID, email, domain.ProviderNylas)
+}
+
+func removeGrantLocally(grantID string) {
+	common.RemoveGrantLocally(grantID)
+}
+
+func ensureNylasConnector(ctx context.Context, client ports.NylasClient) (*domain.Connector, error) {
+	connectors, err := client.ListConnectors(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, connector := range connectors {
+		if connector.Provider == string(domain.ProviderNylas) {
+			return &connector, nil
+		}
+	}
+
+	connector, err := client.CreateConnector(ctx, &domain.CreateConnectorRequest{
+		Name:     "nylas",
+		Provider: string(domain.ProviderNylas),
+	})
+	if err == nil {
+		return connector, nil
+	}
+
+	// Retry discovery once in case another process created it concurrently.
+	connectors, listErr := client.ListConnectors(ctx)
+	if listErr == nil {
+		for _, connector := range connectors {
+			if connector.Provider == string(domain.ProviderNylas) {
+				return &connector, nil
+			}
+		}
+	}
+
+	return nil, err
+}
+
+func resolveAgentID(ctx context.Context, client ports.NylasClient, identifier string) (string, error) {
+	if !strings.Contains(identifier, "@") {
+		return identifier, nil
+	}
+
+	accounts, err := client.ListAgentAccounts(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, account := range accounts {
+		if strings.EqualFold(account.Email, identifier) {
+			return account.ID, nil
+		}
+	}
+
+	return "", common.NewUserError("agent account not found", fmt.Sprintf("No agent account found for email %s", identifier))
+}
+
+func getAgentIdentifier(args []string) (string, error) {
+	if len(args) > 0 {
+		return strings.TrimSpace(args[0]), nil
+	}
+
+	if envID := os.Getenv("NYLAS_AGENT_GRANT_ID"); envID != "" {
+		return envID, nil
+	}
+
+	return "", common.NewUserError("agent ID required", "Provide an agent ID/email or set NYLAS_AGENT_GRANT_ID")
+}

--- a/internal/cli/agent/list.go
+++ b/internal/cli/agent/list.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/nylas/cli/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+func newListCmd() *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List agent accounts",
+		Long: `List all Nylas agent accounts.
+
+This command only shows grants created with provider=nylas.
+
+Examples:
+  nylas agent list
+  nylas agent list --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+
+	return cmd
+}
+
+func runList(jsonOutput bool) error {
+	_, err := common.WithClientNoGrant(func(ctx context.Context, client ports.NylasClient) (struct{}, error) {
+		accounts, err := client.ListAgentAccounts(ctx)
+		if err != nil {
+			return struct{}{}, common.WrapListError("agent accounts", err)
+		}
+
+		if jsonOutput {
+			data, _ := json.MarshalIndent(accounts, "", "  ")
+			fmt.Println(string(data))
+			return struct{}{}, nil
+		}
+
+		if len(accounts) == 0 {
+			common.PrintEmptyStateWithHint("agent accounts", "Create one with: nylas agent create <email>")
+			return struct{}{}, nil
+		}
+
+		_, _ = common.BoldWhite.Printf("Agent Accounts (%d)\n\n", len(accounts))
+		for i, account := range accounts {
+			printAgentSummary(account, i)
+		}
+
+		fmt.Println()
+		_, _ = common.Dim.Println("Use 'nylas agent status' to verify connector readiness")
+		return struct{}{}, nil
+	})
+
+	return err
+}

--- a/internal/cli/agent/status.go
+++ b/internal/cli/agent/status.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+type statusResult struct {
+	ConnectorConfigured bool                  `json:"connector_configured"`
+	ConnectorID         string                `json:"connector_id,omitempty"`
+	AccountCount        int                   `json:"account_count"`
+	Accounts            []domain.AgentAccount `json:"accounts,omitempty"`
+}
+
+func newStatusCmd() *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show agent connector status",
+		Long: `Show the state of the nylas connector and managed agent accounts.
+
+Examples:
+  nylas agent status
+  nylas agent status --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(jsonOutput)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+
+	return cmd
+}
+
+func runStatus(jsonOutput bool) error {
+	_, err := common.WithClientNoGrant(func(ctx context.Context, client ports.NylasClient) (struct{}, error) {
+		connectors, err := client.ListConnectors(ctx)
+		if err != nil {
+			return struct{}{}, common.WrapGetError("connectors", err)
+		}
+
+		connector := findNylasConnector(connectors)
+
+		accounts, err := client.ListAgentAccounts(ctx)
+		if err != nil {
+			return struct{}{}, common.WrapListError("agent accounts", err)
+		}
+
+		result := statusResult{
+			ConnectorConfigured: connector != nil,
+			AccountCount:        len(accounts),
+			Accounts:            accounts,
+		}
+		if connector != nil {
+			result.ConnectorID = connector.ID
+		}
+
+		if jsonOutput {
+			data, _ := json.MarshalIndent(result, "", "  ")
+			fmt.Println(string(data))
+			return struct{}{}, nil
+		}
+
+		_, _ = common.BoldWhite.Println("Agent Status")
+		if result.ConnectorConfigured {
+			if result.ConnectorID != "" {
+				fmt.Printf("  Connector: %s\n", common.Green.Sprintf("ready (%s)", result.ConnectorID))
+			} else {
+				fmt.Printf("  Connector: %s\n", common.Green.Sprint("ready"))
+			}
+		} else {
+			fmt.Printf("  Connector: %s\n", common.Red.Sprint("missing"))
+		}
+		fmt.Printf("  Accounts:  %s\n", common.Cyan.Sprintf("%d", result.AccountCount))
+
+		if len(accounts) > 0 {
+			fmt.Println()
+			for i, account := range accounts {
+				printAgentSummary(account, i)
+			}
+		}
+
+		return struct{}{}, nil
+	})
+
+	return err
+}
+
+func findNylasConnector(connectors []domain.Connector) *domain.Connector {
+	for i := range connectors {
+		if connectors[i].Provider == string(domain.ProviderNylas) {
+			return &connectors[i]
+		}
+	}
+	return nil
+}

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/nylas/cli/internal/cli/testutil"
+	"github.com/nylas/cli/internal/domain"
 	"github.com/spf13/cobra"
 )
 
@@ -145,6 +146,39 @@ func TestLoginCommand(t *testing.T) {
 			t.Error("Expected -p shorthand for --provider")
 		}
 	})
+}
+
+func TestParseLoginProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    domain.Provider
+		wantErr bool
+	}{
+		{name: "google", input: "google", want: domain.ProviderGoogle},
+		{name: "microsoft", input: "microsoft", want: domain.ProviderMicrosoft},
+		{name: "mixed case", input: "Google", want: domain.ProviderGoogle},
+		{name: "reject nylas", input: "nylas", wantErr: true},
+		{name: "reject inbox", input: "inbox", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLoginProvider(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseLoginProvider(%q) expected error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseLoginProvider(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseLoginProvider(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
 }
 
 // TestLogoutCommand tests the logout subcommand.

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -29,10 +30,9 @@ Supported providers:
   # Login with Microsoft/Outlook
   nylas auth login --provider microsoft`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Validate provider
-			p, err := domain.ParseProvider(provider)
+			p, err := parseLoginProvider(provider)
 			if err != nil {
-				return common.NewUserError(fmt.Sprintf("invalid provider: %s", provider), "use 'google' or 'microsoft'")
+				return err
 			}
 
 			// Check if configured
@@ -74,4 +74,15 @@ Supported providers:
 	cmd.Flags().StringVarP(&provider, "provider", "p", "google", "Email provider (google, microsoft)")
 
 	return cmd
+}
+
+func parseLoginProvider(provider string) (domain.Provider, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case string(domain.ProviderGoogle):
+		return domain.ProviderGoogle, nil
+	case string(domain.ProviderMicrosoft):
+		return domain.ProviderMicrosoft, nil
+	default:
+		return "", common.NewUserError(fmt.Sprintf("invalid provider: %s", provider), "use 'google' or 'microsoft'")
+	}
 }

--- a/internal/cli/common/grants.go
+++ b/internal/cli/common/grants.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"github.com/nylas/cli/internal/adapters/config"
+	"github.com/nylas/cli/internal/adapters/keyring"
+	"github.com/nylas/cli/internal/domain"
+)
+
+// FormatGrantStatus renders the common valid/invalid grant states consistently.
+func FormatGrantStatus(status string) string {
+	switch status {
+	case "valid":
+		return Green.Sprint("active")
+	case "invalid":
+		return Red.Sprint("invalid")
+	default:
+		return Yellow.Sprint(status)
+	}
+}
+
+// SaveGrantLocally stores a grant in the local grant store so it can be reused by CLI flows.
+func SaveGrantLocally(grantID, email string, provider domain.Provider) {
+	secretStore, err := keyring.NewSecretStore(config.DefaultConfigDir())
+	if err != nil {
+		return
+	}
+
+	grantStore := keyring.NewGrantStore(secretStore)
+	_ = grantStore.SaveGrant(domain.GrantInfo{
+		ID:       grantID,
+		Email:    email,
+		Provider: provider,
+	})
+}
+
+// RemoveGrantLocally removes a grant from the local grant store.
+func RemoveGrantLocally(grantID string) {
+	secretStore, err := keyring.NewSecretStore(config.DefaultConfigDir())
+	if err != nil {
+		return
+	}
+
+	grantStore := keyring.NewGrantStore(secretStore)
+	_ = grantStore.DeleteGrant(grantID)
+}

--- a/internal/cli/email/send.go
+++ b/internal/cli/email/send.go
@@ -346,11 +346,11 @@ Supports hosted templates:
 				var err error
 
 				// Get grant info to determine provider and email
-				grant, grantErr := client.GetGrant(ctx, grantID)
+				grant, err := getGrantForSend(ctx, client, grantID)
+				if err != nil {
+					return struct{}{}, err
+				}
 				if signatureID != "" {
-					if grantErr != nil {
-						return struct{}{}, common.WrapGetError("grant", grantErr)
-					}
 					if err := validateSendSignatureSupport(signatureID, sign, encrypt, grant); err != nil {
 						return struct{}{}, err
 					}
@@ -360,7 +360,10 @@ Supports hosted templates:
 				}
 
 				if sign || encrypt {
-					if grantErr == nil && grant != nil && grant.Email != "" {
+					if err := validateManagedSecureSendSupport(sign, encrypt, grant); err != nil {
+						return struct{}{}, err
+					}
+					if grant.Email != "" {
 						// Populate From field with grant's email address
 						req.From = []domain.EmailParticipant{
 							{Email: grant.Email},
@@ -381,24 +384,7 @@ Supports hosted templates:
 					spinner := common.NewSpinner(sendMsg)
 					spinner.Start()
 
-					// Auto-detect inbox provider and use transactional endpoint
-					if grantErr == nil && grant != nil && grant.Provider == domain.ProviderInbox {
-						// Inbox provider - use domain-based transactional send
-						emailDomain := common.ExtractDomain(grant.Email)
-						if emailDomain == "" {
-							spinner.Stop()
-							return struct{}{}, common.NewUserError(
-								"could not extract domain from grant email",
-								"Ensure the grant has a valid email address",
-							)
-						}
-						// Set From field for transactional send (required)
-						req.From = []domain.EmailParticipant{{Email: grant.Email}}
-						msg, err = client.SendTransactionalMessage(ctx, emailDomain, req)
-					} else {
-						// Standard provider (Google/Microsoft/IMAP) - use grant-based send
-						msg, err = client.SendMessage(ctx, grantID, req)
-					}
+					msg, err = sendMessageForGrant(ctx, client, grantID, grant, req)
 					spinner.Stop()
 				}
 
@@ -468,6 +454,36 @@ Supports hosted templates:
 	cmd.Flags().BoolVar(&templateOpts.Strict, "template-strict", true, "Fail if a hosted template references missing variables")
 
 	return cmd
+}
+
+func getGrantForSend(ctx context.Context, client ports.NylasClient, grantID string) (*domain.Grant, error) {
+	grant, err := client.GetGrant(ctx, grantID)
+	if err != nil {
+		return nil, common.WrapGetError("grant", err)
+	}
+	return grant, nil
+}
+
+func sendMessageForGrant(
+	ctx context.Context,
+	client ports.NylasClient,
+	grantID string,
+	grant *domain.Grant,
+	req *domain.SendMessageRequest,
+) (*domain.Message, error) {
+	if isManagedTransactionalGrant(grant) {
+		emailDomain := common.ExtractDomain(grant.Email)
+		if emailDomain == "" {
+			return nil, common.NewUserError(
+				"could not extract domain from grant email",
+				"Ensure the grant has a valid email address",
+			)
+		}
+		req.From = []domain.EmailParticipant{{Email: grant.Email}}
+		return client.SendTransactionalMessage(ctx, emailDomain, req)
+	}
+
+	return client.SendMessage(ctx, grantID, req)
 }
 
 func shouldUseInteractiveSendMode(

--- a/internal/cli/email/send_managed_test.go
+++ b/internal/cli/email/send_managed_test.go
@@ -1,0 +1,169 @@
+package email
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nylas/cli/internal/adapters/nylas"
+	"github.com/nylas/cli/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendMessageForGrant_UsesTransactionalSendForManagedProviders(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider domain.Provider
+		email    string
+	}{
+		{
+			name:     "inbox grant uses transactional send",
+			provider: domain.ProviderInbox,
+			email:    "info@qasim.nylas.email",
+		},
+		{
+			name:     "nylas grant uses transactional send",
+			provider: domain.ProviderNylas,
+			email:    "xyz@qasim.nylas.email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := nylas.NewMockClient()
+			client.SendMessageFunc = func(ctx context.Context, grantID string, req *domain.SendMessageRequest) (*domain.Message, error) {
+				t.Fatalf("SendMessage should not be called for managed provider %s", tt.provider)
+				return nil, nil
+			}
+
+			var gotDomain string
+			var gotFrom []domain.EmailParticipant
+			nylas.SendTransactionalMessageFunc = func(ctx context.Context, domainName string, req *domain.SendMessageRequest) (*domain.Message, error) {
+				gotDomain = domainName
+				gotFrom = append([]domain.EmailParticipant(nil), req.From...)
+				return &domain.Message{ID: "txn-msg-id", Subject: req.Subject}, nil
+			}
+			t.Cleanup(func() {
+				nylas.SendTransactionalMessageFunc = nil
+			})
+
+			req := &domain.SendMessageRequest{
+				Subject: "Hello",
+				Body:    "Body",
+				To:      []domain.EmailParticipant{{Email: "to@example.com"}},
+			}
+			grant := &domain.Grant{
+				ID:       "grant-123",
+				Provider: tt.provider,
+				Email:    tt.email,
+			}
+
+			msg, err := sendMessageForGrant(context.Background(), client, "grant-123", grant, req)
+
+			require.NoError(t, err)
+			require.NotNil(t, msg)
+			assert.Equal(t, "txn-msg-id", msg.ID)
+			assert.False(t, client.SendMessageCalled)
+			assert.Equal(t, "qasim.nylas.email", gotDomain)
+			require.Len(t, gotFrom, 1)
+			assert.Equal(t, tt.email, gotFrom[0].Email)
+			require.Len(t, req.From, 1)
+			assert.Equal(t, tt.email, req.From[0].Email)
+		})
+	}
+}
+
+func TestSendMessageForGrant_UsesGrantSendForStandardProviders(t *testing.T) {
+	client := nylas.NewMockClient()
+
+	var gotGrantID string
+	var gotFrom []domain.EmailParticipant
+	client.SendMessageFunc = func(ctx context.Context, grantID string, req *domain.SendMessageRequest) (*domain.Message, error) {
+		gotGrantID = grantID
+		gotFrom = append([]domain.EmailParticipant(nil), req.From...)
+		return &domain.Message{ID: "grant-msg-id", Subject: req.Subject}, nil
+	}
+
+	nylas.SendTransactionalMessageFunc = func(ctx context.Context, domainName string, req *domain.SendMessageRequest) (*domain.Message, error) {
+		t.Fatalf("SendTransactionalMessage should not be called for standard providers")
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		nylas.SendTransactionalMessageFunc = nil
+	})
+
+	req := &domain.SendMessageRequest{
+		Subject: "Hello",
+		Body:    "Body",
+		To:      []domain.EmailParticipant{{Email: "to@example.com"}},
+	}
+	grant := &domain.Grant{
+		ID:       "grant-456",
+		Provider: domain.ProviderGoogle,
+		Email:    "user@example.com",
+	}
+
+	msg, err := sendMessageForGrant(context.Background(), client, "grant-456", grant, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, "grant-msg-id", msg.ID)
+	assert.Equal(t, "grant-456", gotGrantID)
+	assert.Empty(t, gotFrom)
+	assert.Empty(t, req.From)
+}
+
+func TestValidateManagedSecureSendSupport(t *testing.T) {
+	tests := []struct {
+		name      string
+		sign      bool
+		encrypt   bool
+		grant     *domain.Grant
+		wantError bool
+	}{
+		{
+			name:      "managed nylas sign is rejected",
+			sign:      true,
+			grant:     &domain.Grant{Provider: domain.ProviderNylas},
+			wantError: true,
+		},
+		{
+			name:      "managed inbox encrypt is rejected",
+			encrypt:   true,
+			grant:     &domain.Grant{Provider: domain.ProviderInbox},
+			wantError: true,
+		},
+		{
+			name:      "standard provider sign is allowed",
+			sign:      true,
+			grant:     &domain.Grant{Provider: domain.ProviderGoogle},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateManagedSecureSendSupport(tt.sign, tt.encrypt, tt.grant)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGetGrantForSend_PropagatesLookupFailure(t *testing.T) {
+	client := nylas.NewMockClient()
+	client.GetGrantFunc = func(ctx context.Context, grantID string) (*domain.Grant, error) {
+		return nil, errors.New("temporary lookup failure")
+	}
+
+	grant, err := getGrantForSend(context.Background(), client, "grant-123")
+
+	require.Error(t, err)
+	assert.Nil(t, grant)
+	assert.ErrorContains(t, err, "failed to get grant")
+	assert.ErrorContains(t, err, "temporary lookup failure")
+}

--- a/internal/cli/email/signatures_support.go
+++ b/internal/cli/email/signatures_support.go
@@ -10,6 +10,10 @@ import (
 	"github.com/nylas/cli/internal/ports"
 )
 
+func isManagedTransactionalGrant(grant *domain.Grant) bool {
+	return grant != nil && (grant.Provider == domain.ProviderInbox || grant.Provider == domain.ProviderNylas)
+}
+
 func validateSendSignatureSupport(signatureID string, sign, encrypt bool, grant *domain.Grant) error {
 	if signatureID == "" {
 		return nil
@@ -20,13 +24,26 @@ func validateSendSignatureSupport(signatureID string, sign, encrypt bool, grant 
 			"Use standard JSON send mode without --sign/--encrypt, or add the signature HTML directly to the message body",
 		)
 	}
-	if grant != nil && grant.Provider == domain.ProviderInbox {
+	if isManagedTransactionalGrant(grant) {
 		return common.NewUserError(
-			"`--signature-id` is not supported for Inbox transactional sends",
-			"Inbox grants use the domain-based transactional send endpoint, which does not accept signature_id",
+			"`--signature-id` is not supported for managed transactional sends",
+			"Managed Nylas grants use the domain-based transactional send endpoint, which does not accept signature_id",
 		)
 	}
 	return nil
+}
+
+func validateManagedSecureSendSupport(sign, encrypt bool, grant *domain.Grant) error {
+	if !sign && !encrypt {
+		return nil
+	}
+	if !isManagedTransactionalGrant(grant) {
+		return nil
+	}
+	return common.NewUserError(
+		"`--sign` and `--encrypt` are not supported for managed transactional sends",
+		"Managed Nylas grants use the domain-based transactional send endpoint, which does not support raw MIME GPG send",
+	)
 }
 
 func validateSignatureSelection(

--- a/internal/cli/email/signatures_test.go
+++ b/internal/cli/email/signatures_test.go
@@ -141,7 +141,25 @@ func TestValidateSignatureSelection(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Nil(t, signatures)
-		assert.ErrorContains(t, err, "`--signature-id` is not supported for Inbox transactional sends")
+		assert.ErrorContains(t, err, "`--signature-id` is not supported for managed transactional sends")
+		assert.False(t, mock.GetGrantCalled)
+		assert.False(t, mock.GetSignaturesCalled)
+	})
+
+	t.Run("rejects nylas grants before listing signatures", func(t *testing.T) {
+		mock := nylas.NewMockClient()
+
+		signatures, err := validateSignatureSelection(
+			ctx,
+			mock,
+			"grant-123",
+			"sig-123",
+			&domain.Grant{Provider: domain.ProviderNylas},
+		)
+
+		require.Error(t, err)
+		assert.Nil(t, signatures)
+		assert.ErrorContains(t, err, "`--signature-id` is not supported for managed transactional sends")
 		assert.False(t, mock.GetGrantCalled)
 		assert.False(t, mock.GetSignaturesCalled)
 	})

--- a/internal/cli/inbound/helpers.go
+++ b/internal/cli/inbound/helpers.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nylas/cli/internal/adapters/config"
-	"github.com/nylas/cli/internal/adapters/keyring"
 	"github.com/nylas/cli/internal/cli/common"
 	"github.com/nylas/cli/internal/domain"
 )
@@ -72,38 +70,17 @@ func printInboxDetails(inbox domain.InboundInbox) {
 
 // formatStatus formats the grant status with color.
 func formatStatus(status string) string {
-	switch status {
-	case "valid":
-		return common.Green.Sprint("active")
-	case "invalid":
-		return common.Red.Sprint("invalid")
-	default:
-		return common.Yellow.Sprint(status)
-	}
+	return common.FormatGrantStatus(status)
 }
 
 // saveGrantLocally saves the inbound inbox grant to the local keyring store.
 func saveGrantLocally(grantID, email string) {
-	secretStore, err := keyring.NewSecretStore(config.DefaultConfigDir())
-	if err != nil {
-		return
-	}
-	grantStore := keyring.NewGrantStore(secretStore)
-	_ = grantStore.SaveGrant(domain.GrantInfo{
-		ID:       grantID,
-		Email:    email,
-		Provider: domain.ProviderInbox,
-	})
+	common.SaveGrantLocally(grantID, email, domain.ProviderInbox)
 }
 
 // removeGrantLocally removes the inbound inbox grant from the local keyring store.
 func removeGrantLocally(grantID string) {
-	secretStore, err := keyring.NewSecretStore(config.DefaultConfigDir())
-	if err != nil {
-		return
-	}
-	grantStore := keyring.NewGrantStore(secretStore)
-	_ = grantStore.DeleteGrant(grantID)
+	common.RemoveGrantLocally(grantID)
 }
 
 // printInboundMessageSummary prints an inbound message summary.

--- a/internal/cli/integration/agent_test.go
+++ b/internal/cli/integration/agent_test.go
@@ -1,0 +1,300 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+func TestCLI_AgentLifecycle_CreateListDeleteByEmail(t *testing.T) {
+	skipIfMissingCreds(t)
+	skipIfMissingAgentDomain(t)
+
+	env := newAgentSandboxEnv(t)
+	email := newAgentTestEmail(t, "lifecycle")
+	appPassword := validAgentTestPassword()
+	client := getTestClient()
+
+	var created *domain.AgentAccount
+	t.Cleanup(func() {
+		if created == nil {
+			return
+		}
+		if exists, account := waitForAgentByEmail(t, client, email, true); exists {
+			acquireRateLimit(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = client.DeleteAgentAccount(ctx, account.ID)
+		}
+	})
+
+	stdout, stderr, err := runCLIWithOverridesAndRateLimit(t, 2*time.Minute, env, "agent", "create", email, "--app-password", appPassword, "--json")
+	if err != nil {
+		t.Fatalf("agent create failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	var account domain.AgentAccount
+	if err := json.Unmarshal([]byte(stdout), &account); err != nil {
+		t.Fatalf("failed to parse agent create JSON: %v\noutput: %s", err, stdout)
+	}
+	if account.Email != email {
+		t.Fatalf("created email = %q, want %q", account.Email, email)
+	}
+	if account.Provider != domain.ProviderNylas {
+		t.Fatalf("created provider = %q, want %q", account.Provider, domain.ProviderNylas)
+	}
+	if strings.TrimSpace(account.ID) == "" {
+		t.Fatalf("expected created agent account ID, got empty output: %s", stdout)
+	}
+	created = &account
+
+	if exists, _ := waitForAgentByEmail(t, client, email, true); !exists {
+		t.Fatalf("created agent account %q did not appear in list", email)
+	}
+
+	listStdout, listStderr, err := runCLIWithOverridesAndRateLimit(t, 2*time.Minute, env, "agent", "list", "--json")
+	if err != nil {
+		t.Fatalf("agent list failed: %v\nstdout: %s\nstderr: %s", err, listStdout, listStderr)
+	}
+
+	var accounts []domain.AgentAccount
+	if err := json.Unmarshal([]byte(listStdout), &accounts); err != nil {
+		t.Fatalf("failed to parse agent list JSON: %v\noutput: %s", err, listStdout)
+	}
+
+	found := false
+	for _, listed := range accounts {
+		if listed.Provider != domain.ProviderNylas {
+			t.Fatalf("agent list returned non-nylas provider %q in %+v", listed.Provider, listed)
+		}
+		if listed.Email == email {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("agent list did not include created account %q\noutput: %s", email, listStdout)
+	}
+
+	deleteStdout, deleteStderr, err := runCLIWithOverridesAndRateLimit(t, 2*time.Minute, env, "agent", "delete", email, "--yes")
+	if err != nil {
+		t.Fatalf("agent delete by email failed: %v\nstdout: %s\nstderr: %s", err, deleteStdout, deleteStderr)
+	}
+	if !strings.Contains(strings.ToLower(deleteStdout), "deleted successfully") {
+		t.Fatalf("expected delete confirmation in stdout, got: %s", deleteStdout)
+	}
+
+	if exists, _ := waitForAgentByEmail(t, client, email, false); exists {
+		t.Fatalf("agent account %q still exists after delete", email)
+	}
+	created = nil
+}
+
+func TestCLI_AgentDelete_ByID(t *testing.T) {
+	skipIfMissingCreds(t)
+	skipIfMissingAgentDomain(t)
+
+	env := newAgentSandboxEnv(t)
+	client := getTestClient()
+	email := newAgentTestEmail(t, "delete-id")
+	account := createAgentForTest(t, client, email)
+
+	t.Cleanup(func() {
+		if exists, listed := waitForAgentByEmail(t, client, email, true); exists {
+			acquireRateLimit(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = client.DeleteAgentAccount(ctx, listed.ID)
+		}
+	})
+
+	stdout, stderr, err := runCLIWithOverridesAndRateLimit(t, 2*time.Minute, env, "agent", "delete", account.ID, "--yes")
+	if err != nil {
+		t.Fatalf("agent delete by ID failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	if exists, _ := waitForAgentByEmail(t, client, email, false); exists {
+		t.Fatalf("agent account %q still exists after delete by ID", email)
+	}
+}
+
+func TestCLI_AgentDelete_CancelKeepsAccount(t *testing.T) {
+	skipIfMissingCreds(t)
+	skipIfMissingAgentDomain(t)
+
+	env := newAgentSandboxEnv(t)
+	client := getTestClient()
+	email := newAgentTestEmail(t, "cancel")
+	account := createAgentForTest(t, client, email)
+
+	t.Cleanup(func() {
+		if exists, listed := waitForAgentByEmail(t, client, email, true); exists {
+			acquireRateLimit(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = client.DeleteAgentAccount(ctx, listed.ID)
+		}
+	})
+
+	acquireRateLimit(t)
+	stdout, stderr, err := runCLIWithInputAndOverrides(2*time.Minute, "n\n", env, "agent", "delete", account.Email)
+	if err != nil {
+		t.Fatalf("agent delete cancel flow failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "Deletion cancelled.") {
+		t.Fatalf("expected cancellation message, got stdout: %s", stdout)
+	}
+
+	if exists, listed := waitForAgentByEmail(t, client, email, true); !exists || listed.ID != account.ID {
+		t.Fatalf("agent account %q should still exist after cancellation", email)
+	}
+}
+
+func TestCLI_AgentCreate_RequiresEmail(t *testing.T) {
+	skipIfMissingCreds(t)
+
+	stdout, stderr, err := runCLI("agent", "create")
+	if err == nil {
+		t.Fatalf("expected agent create without email to fail\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(strings.ToLower(stderr), "accepts 1 arg") && !strings.Contains(strings.ToLower(stderr), "argument") {
+		t.Fatalf("expected missing argument error, got stderr: %s", stderr)
+	}
+}
+
+func TestCLI_AgentCreate_InvalidEmailWithSpaces(t *testing.T) {
+	skipIfMissingCreds(t)
+	skipIfMissingAgentDomain(t)
+
+	env := newAgentSandboxEnv(t)
+	stdout, stderr, err := runCLIWithOverrides(30*time.Second, env, "agent", "create", "bad email")
+	if err == nil {
+		t.Fatalf("expected invalid email with spaces to fail\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "should not contain spaces") {
+		t.Fatalf("expected invalid email error, got stderr: %s", stderr)
+	}
+}
+
+func TestCLI_AgentDelete_InvalidIdentifier(t *testing.T) {
+	skipIfMissingCreds(t)
+
+	env := newAgentSandboxEnv(t)
+	stdout, stderr, err := runCLIWithOverridesAndRateLimit(t, 30*time.Second, env, "agent", "delete", "invalid-agent-id", "--yes")
+	if err == nil {
+		t.Fatalf("expected invalid agent delete to fail\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(strings.ToLower(stderr), "not found") && !strings.Contains(strings.ToLower(stderr), "failed to get agent account") {
+		t.Fatalf("expected not found error, got stderr: %s", stderr)
+	}
+}
+
+func skipIfMissingAgentDomain(t *testing.T) {
+	t.Helper()
+	if strings.TrimSpace(os.Getenv("NYLAS_AGENT_DOMAIN")) == "" {
+		t.Skip("NYLAS_AGENT_DOMAIN not set - skipping agent account lifecycle tests")
+	}
+}
+
+func newAgentSandboxEnv(t *testing.T) map[string]string {
+	t.Helper()
+	configHome := t.TempDir()
+	return map[string]string{
+		"XDG_CONFIG_HOME":             configHome,
+		"HOME":                        configHome,
+		"NYLAS_DISABLE_KEYRING":       "true",
+		"NYLAS_FILE_STORE_PASSPHRASE": "integration-test-file-store-passphrase",
+		"NYLAS_GRANT_ID":              "",
+	}
+}
+
+func newAgentTestEmail(t *testing.T, prefix string) string {
+	t.Helper()
+	domainName := strings.TrimSpace(os.Getenv("NYLAS_AGENT_DOMAIN"))
+	domainName = strings.Trim(domainName, `"'`)
+	domainName = strings.TrimPrefix(domainName, "@")
+	if domainName == "" {
+		t.Fatal("NYLAS_AGENT_DOMAIN is empty")
+	}
+	slug := strings.ReplaceAll(prefix, "_", "-")
+	return fmt.Sprintf("it-%s-%d@%s", slug, time.Now().UnixNano(), domainName)
+}
+
+func createAgentForTest(t *testing.T, client interface {
+	CreateAgentAccount(context.Context, string, string) (*domain.AgentAccount, error)
+}, email string) *domain.AgentAccount {
+	t.Helper()
+	acquireRateLimit(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	account, err := client.CreateAgentAccount(ctx, email, "")
+	if err != nil {
+		t.Fatalf("failed to create agent account %q for test setup: %v", email, err)
+	}
+	return account
+}
+
+func validAgentTestPassword() string {
+	return "ValidAgentPass123ABC!"
+}
+
+func waitForAgentByEmail(t *testing.T, client interface {
+	ListAgentAccounts(context.Context) ([]domain.AgentAccount, error)
+}, email string, wantPresent bool) (bool, *domain.AgentAccount) {
+	t.Helper()
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		acquireRateLimit(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		accounts, err := client.ListAgentAccounts(ctx)
+		cancel()
+		if err == nil {
+			for i := range accounts {
+				if strings.EqualFold(accounts[i].Email, email) {
+					if wantPresent {
+						return true, &accounts[i]
+					}
+					time.Sleep(500 * time.Millisecond)
+					goto next
+				}
+			}
+			if !wantPresent {
+				return false, nil
+			}
+		}
+
+	next:
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if wantPresent {
+		return false, nil
+	}
+	return true, nil
+}
+
+func runCLIWithInputAndOverrides(timeout time.Duration, input string, envOverrides map[string]string, args ...string) (string, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, testBinary, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Stdin = strings.NewReader(input)
+	cmd.Env = cliTestEnv(envOverrides)
+
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -1,0 +1,24 @@
+package domain
+
+// AgentAccount represents a Nylas-managed agent account grant (provider=nylas).
+type AgentAccount struct {
+	ID           string               `json:"id"`
+	Provider     Provider             `json:"provider"`
+	Email        string               `json:"email"`
+	GrantStatus  string               `json:"grant_status"`
+	Settings     AgentAccountSettings `json:"settings,omitempty"`
+	CreatedAt    UnixTime             `json:"created_at,omitempty"`
+	UpdatedAt    UnixTime             `json:"updated_at,omitempty"`
+	CredentialID string               `json:"credential_id,omitempty"`
+	Blocked      bool                 `json:"blocked,omitempty"`
+}
+
+// AgentAccountSettings contains provider-managed metadata for agent accounts.
+type AgentAccountSettings struct {
+	PolicyID string `json:"policy_id,omitempty"`
+}
+
+// IsValid returns true if the agent account grant is in a valid state.
+func (a *AgentAccount) IsValid() bool {
+	return a.GrantStatus == "valid"
+}

--- a/internal/domain/basic_test.go
+++ b/internal/domain/basic_test.go
@@ -15,6 +15,7 @@ func TestProvider(t *testing.T) {
 			{ProviderMicrosoft, "Microsoft"},
 			{ProviderIMAP, "IMAP"},
 			{ProviderVirtual, "Virtual"},
+			{ProviderNylas, "Nylas"},
 			{Provider("unknown"), "unknown"},
 		}
 
@@ -35,6 +36,7 @@ func TestProvider(t *testing.T) {
 			{ProviderMicrosoft, true},
 			{ProviderIMAP, true},
 			{ProviderVirtual, true},
+			{ProviderNylas, true},
 			{Provider("unknown"), false},
 			{Provider(""), false},
 			{Provider("GOOGLE"), false}, // Case sensitive
@@ -58,6 +60,7 @@ func TestProvider(t *testing.T) {
 			{ProviderIMAP, false},
 			{ProviderVirtual, false},
 			{ProviderInbox, false},
+			{ProviderNylas, false},
 			{Provider("unknown"), false},
 		}
 
@@ -79,6 +82,7 @@ func TestProvider(t *testing.T) {
 			{"microsoft", ProviderMicrosoft, false},
 			{"imap", ProviderIMAP, false},
 			{"virtual", ProviderVirtual, false},
+			{"nylas", ProviderNylas, false},
 			{"unknown", "", true},
 			{"", "", true},
 			{"GOOGLE", "", true}, // Case sensitive

--- a/internal/domain/provider.go
+++ b/internal/domain/provider.go
@@ -11,6 +11,7 @@ const (
 	ProviderIMAP      Provider = "imap"
 	ProviderVirtual   Provider = "virtual"
 	ProviderInbox     Provider = "inbox" // Nylas Native Auth
+	ProviderNylas     Provider = "nylas"
 )
 
 // SupportedAirProviders lists providers supported by the Air web UI.
@@ -29,6 +30,8 @@ func (p Provider) DisplayName() string {
 		return "Virtual"
 	case ProviderInbox:
 		return "Inbox"
+	case ProviderNylas:
+		return "Nylas"
 	default:
 		return string(p)
 	}
@@ -37,7 +40,7 @@ func (p Provider) DisplayName() string {
 // IsValid checks if the provider is a known type.
 func (p Provider) IsValid() bool {
 	switch p {
-	case ProviderGoogle, ProviderMicrosoft, ProviderIMAP, ProviderVirtual, ProviderInbox:
+	case ProviderGoogle, ProviderMicrosoft, ProviderIMAP, ProviderVirtual, ProviderInbox, ProviderNylas:
 		return true
 	default:
 		return false

--- a/internal/ports/agent.go
+++ b/internal/ports/agent.go
@@ -1,0 +1,23 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+// AgentClient defines the interface for Nylas-managed agent account operations.
+type AgentClient interface {
+	// ListAgentAccounts retrieves all agent accounts (provider=nylas).
+	ListAgentAccounts(ctx context.Context) ([]domain.AgentAccount, error)
+
+	// GetAgentAccount retrieves a specific agent account grant by ID.
+	GetAgentAccount(ctx context.Context, grantID string) (*domain.AgentAccount, error)
+
+	// CreateAgentAccount creates a new agent account with the given email address.
+	// appPassword is optional and enables IMAP/SMTP client access when set.
+	CreateAgentAccount(ctx context.Context, email, appPassword string) (*domain.AgentAccount, error)
+
+	// DeleteAgentAccount deletes an agent account by revoking its grant.
+	DeleteAgentAccount(ctx context.Context, grantID string) error
+}

--- a/internal/ports/nylas.go
+++ b/internal/ports/nylas.go
@@ -18,6 +18,7 @@ type NylasClient interface {
 	PubSubClient
 	NotetakerClient
 	InboundClient
+	AgentClient
 	SchedulerClient
 	AdminClient
 	TransactionalClient


### PR DESCRIPTION
## Summary
- add `nylas agent` command support for `create`, `list`, `delete`, and `status`
- hardcode `provider=nylas` for agent account flows and verify connector readiness before create
- support `--app-password` during agent account creation for IMAP/SMTP mail-client access
- route `provider=nylas` email sends through the same managed transactional path as `provider=inbox`
- block unsupported managed secure-send flows instead of falling back to the wrong endpoint
- repair stale local grant state after deleting default or malformed managed grants
- update docs and add unit/integration coverage for the new behavior

## Details
### Agent Accounts
- adds a dedicated `nylas agent` command surface
- uses the `nylas` connector path and managed grant APIs for agent account CRUD
- handles wrapped and flat create responses correctly
- paginates managed grant listing so list/status/delete-by-email continue to work beyond the first page

### App Password Support
- adds `--app-password` to `nylas agent create`
- validates password requirements locally before calling the API
- documents mail-client setup expectations for Agent Accounts

### Managed Send Parity
- treats `provider=nylas` the same as `provider=inbox` for managed transactional send
- uses the grant email as the sender for managed-domain sends
- surfaces grant lookup failures instead of silently falling back to the wrong send path

### Local Grant State Repair
- prevents invalid local grants with empty IDs or emails from being persisted
- repairs malformed local grant entries on read
- repairs `default_grant` state when a default grant is deleted or missing

## Testing
- `make ci-full`

## Jira
- Parent: [TT-4304](https://nylas.atlassian.net/browse/TT-4304)
- [TT-4406](https://nylas.atlassian.net/browse/TT-4406) `nylas agent` command surface
- [TT-4407](https://nylas.atlassian.net/browse/TT-4407) connector bootstrap and readiness checks
- [TT-4408](https://nylas.atlassian.net/browse/TT-4408) `--app-password` support
- [TT-4409](https://nylas.atlassian.net/browse/TT-4409) managed send parity for `provider=nylas`
- [TT-4410](https://nylas.atlassian.net/browse/TT-4410) docs updates
- [TT-4411](https://nylas.atlassian.net/browse/TT-4411) unit and integration coverage


[TT-4304]: https://nylas.atlassian.net/browse/TT-4304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ