### PR TITLE
TW-4843 Harden CLI retry, dashboard auth, and updater flows

### DIFF
--- a/internal/adapters/dashboard/http.go
+++ b/internal/adapters/dashboard/http.go
@@ -24,10 +24,9 @@ func newNonRedirectClient() *http.Client {
 	}
 }
 
-// doPost sends a JSON POST request and decodes the response into result.
-// The server wraps responses in {"request_id","success","data":{...}}.
-// This method unwraps the data field before decoding into result.
-// If result is nil, the response body is discarded.
+// doPost sends a JSON POST request and decodes the already-unwrapped payload
+// returned by doPostRaw into result. If result is nil, the response body is
+// discarded.
 func (c *AccountClient) doPost(ctx context.Context, path string, body any, extraHeaders map[string]string, accessToken string, result any) error {
 	raw, err := c.doPostRaw(ctx, path, body, extraHeaders, accessToken)
 	if err != nil {
@@ -35,11 +34,7 @@ func (c *AccountClient) doPost(ctx context.Context, path string, body any, extra
 	}
 
 	if result != nil {
-		data, unwrapErr := unwrapEnvelope(raw)
-		if unwrapErr != nil {
-			return unwrapErr
-		}
-		if err := json.Unmarshal(data, result); err != nil {
+		if err := json.Unmarshal(raw, result); err != nil {
 			return fmt.Errorf("failed to decode response: %w", err)
 		}
 	}

--- a/internal/adapters/dashboard/http_test.go
+++ b/internal/adapters/dashboard/http_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockDPoP implements ports.DPoP for testing.
@@ -245,4 +248,40 @@ func TestDoPostAndGet_Integration(t *testing.T) {
 			t.Errorf("result[name] = %q, want %q", result["name"], "Test App")
 		}
 	})
+}
+
+func TestDoPost_PreservesNestedDataField(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"request_id": "test-456",
+			"success":    true,
+			"data": map[string]any{
+				"id": "app-1",
+				"data": map[string]string{
+					"inner": "value",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &AccountClient{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		dpop:       &mockDPoP{proof: "test-proof"},
+	}
+
+	var result struct {
+		ID   string            `json:"id"`
+		Data map[string]string `json:"data"`
+	}
+
+	err := client.doPost(context.Background(), "/test", nil, nil, "token", &result)
+	require.NoError(t, err)
+	assert.Equal(t, "app-1", result.ID)
+	assert.Equal(t, map[string]string{"inner": "value"}, result.Data)
 }

--- a/internal/adapters/nylas/client.go
+++ b/internal/adapters/nylas/client.go
@@ -164,6 +164,32 @@ func (c *HTTPClient) ensureContext(ctx context.Context) (context.Context, contex
 	return context.WithTimeout(ctx, c.requestTimeout)
 }
 
+// cloneRequestForAttempt creates a fresh request instance for a retry attempt.
+// When the request has a body, retries must reopen it via GetBody so the payload
+// is replayed instead of sending an empty request after the first attempt.
+func cloneRequestForAttempt(req *http.Request, ctx context.Context, attempt int) (*http.Request, error) {
+	reqToUse := req.Clone(ctx)
+	if req.Body == nil {
+		return reqToUse, nil
+	}
+
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("failed to replay request body: %w", err)
+		}
+		reqToUse.Body = body
+		return reqToUse, nil
+	}
+
+	if attempt == 0 {
+		reqToUse.Body = req.Body
+		return reqToUse, nil
+	}
+
+	return nil, fmt.Errorf("request body cannot be retried safely")
+}
+
 // doRequest executes an HTTP request with rate limiting and timeout.
 // This method applies rate limiting before making the request and ensures
 // the context has a timeout to prevent hanging requests.
@@ -183,13 +209,10 @@ func (c *HTTPClient) doRequest(ctx context.Context, req *http.Request) (*http.Re
 		// Ensure context has timeout
 		ctxWithTimeout, cancel := c.ensureContext(ctx)
 
-		// Optimize: on first attempt, use WithContext to avoid allocation.
-		// On retries, we must clone since the original request was already used.
-		var reqToUse *http.Request
-		if attempt == 0 {
-			reqToUse = req.WithContext(ctxWithTimeout)
-		} else {
-			reqToUse = req.Clone(ctxWithTimeout)
+		reqToUse, err := cloneRequestForAttempt(req, ctxWithTimeout, attempt)
+		if err != nil {
+			cancel()
+			return nil, err
 		}
 
 		// Execute request

--- a/internal/adapters/nylas/messages_update_test.go
+++ b/internal/adapters/nylas/messages_update_test.go
@@ -6,6 +6,7 @@ package nylas_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -103,6 +104,56 @@ func TestHTTPClient_UpdateMessage(t *testing.T) {
 			assert.Equal(t, "msg-456", message.ID)
 		})
 	}
+}
+
+func TestHTTPClient_UpdateMessage_RetriesReplayBody(t *testing.T) {
+	t.Parallel()
+
+	var requestBodies []string
+	attempts := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requestBodies = append(requestBodies, string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{"message": "Rate limit exceeded"},
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"id":       "msg-456",
+				"grant_id": "grant-123",
+				"subject":  "Updated",
+				"date":     1704067200,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := nylas.NewHTTPClient()
+	client.SetCredentials("client-id", "secret", "api-key")
+	client.SetBaseURL(server.URL)
+	client.SetMaxRetries(1)
+
+	unread := false
+	message, err := client.UpdateMessage(context.Background(), "grant-123", "msg-456", &domain.UpdateMessageRequest{
+		Unread: &unread,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, message)
+	require.Len(t, requestBodies, 2)
+	assert.NotEmpty(t, requestBodies[0])
+	assert.Equal(t, requestBodies[0], requestBodies[1], "retried request should replay the original JSON body")
 }
 
 func TestHTTPClient_DeleteMessage(t *testing.T) {

--- a/internal/cli/dashboard/dashboard_test.go
+++ b/internal/cli/dashboard/dashboard_test.go
@@ -1,14 +1,44 @@
 package dashboard
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dashboardadapter "github.com/nylas/cli/internal/adapters/dashboard"
+	dashboardapp "github.com/nylas/cli/internal/app/dashboard"
 	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/ports"
 )
+
+type memSecretStore struct {
+	data map[string]string
+}
+
+func newMemSecretStore() *memSecretStore {
+	return &memSecretStore{data: make(map[string]string)}
+}
+
+func (m *memSecretStore) Set(key, value string) error {
+	m.data[key] = value
+	return nil
+}
+
+func (m *memSecretStore) Get(key string) (string, error) {
+	return m.data[key], nil
+}
+
+func (m *memSecretStore) Delete(key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *memSecretStore) IsAvailable() bool { return true }
+
+func (m *memSecretStore) Name() string { return "mem" }
 
 func TestResolveAuthMethod(t *testing.T) {
 	t.Parallel()
@@ -195,4 +225,40 @@ func TestToAppRows(t *testing.T) {
 		Environment:   "sandbox",
 		Name:          "",
 	}, rows[1])
+}
+
+func TestPersistActiveOrgSwitchesServerSession(t *testing.T) {
+	t.Parallel()
+
+	store := newMemSecretStore()
+	require.NoError(t, store.Set(ports.KeyDashboardUserToken, "user-token"))
+	require.NoError(t, store.Set(ports.KeyDashboardOrgToken, "org-token"))
+
+	var switchedOrg string
+	authSvc := dashboardapp.NewAuthService(&dashboardadapter.MockAccountClient{
+		SwitchOrgFn: func(_ context.Context, orgPublicID, userToken, orgToken string) (*domain.DashboardSwitchOrgResponse, error) {
+			switchedOrg = orgPublicID
+			assert.Equal(t, "user-token", userToken)
+			assert.Equal(t, "org-token", orgToken)
+			return &domain.DashboardSwitchOrgResponse{
+				OrgToken: "new-org-token",
+				Org:      domain.DashboardSwitchOrgOrg{PublicID: orgPublicID},
+			}, nil
+		},
+	}, store)
+
+	err := persistActiveOrg(authSvc, &domain.DashboardAuthResponse{
+		Organizations: []domain.DashboardOrganization{
+			{PublicID: "org-1", Name: "Org One"},
+			{PublicID: "org-2", Name: "Org Two"},
+		},
+	}, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, "org-1", switchedOrg, "non-interactive selection should fall back to the first org")
+
+	storedOrgID, _ := store.Get(ports.KeyDashboardOrgPublicID)
+	assert.Equal(t, "org-1", storedOrgID)
+	storedOrgToken, _ := store.Get(ports.KeyDashboardOrgToken)
+	assert.Equal(t, "new-org-token", storedOrgToken)
 }

--- a/internal/cli/dashboard/helpers.go
+++ b/internal/cli/dashboard/helpers.go
@@ -186,8 +186,14 @@ func persistActiveOrg(authSvc *dashboardapp.AuthService, auth *domain.DashboardA
 	if selectedOrgID == "" {
 		return nil
 	}
-	if err := authSvc.SetActiveOrg(selectedOrgID); err != nil {
-		return fmt.Errorf("failed to store selected organization: %w", err)
+
+	// Apply the selection to the server-side dashboard session so follow-up
+	// commands use the same org the user chose during login.
+	switchCtx, switchCancel := common.CreateContext()
+	defer switchCancel()
+
+	if _, err := authSvc.SwitchOrg(switchCtx, selectedOrgID); err != nil {
+		return fmt.Errorf("failed to switch organization: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/update/installer.go
+++ b/internal/cli/update/installer.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -24,6 +25,13 @@ const binaryName = "nylas"
 // maxBinarySize is the maximum allowed size for the extracted binary (100MB).
 // This prevents decompression bomb attacks (G110).
 const maxBinarySize = 100 * 1024 * 1024
+
+var startDetachedUpdateCommand = func(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Start()
+}
 
 // getAssetName returns the expected asset name for the current platform.
 func getAssetName(version string) string {
@@ -286,10 +294,18 @@ func isHomebrewInstall() bool {
 
 // installBinary replaces the current binary with the new one.
 func installBinary(newBinaryPath, targetPath string) error {
+	return installBinaryForOS(newBinaryPath, targetPath, runtime.GOOS)
+}
+
+func installBinaryForOS(newBinaryPath, targetPath, goos string) error {
 	// Check if we can write to the target directory
 	targetDir := filepath.Dir(targetPath)
 	if err := checkWritePermission(targetDir); err != nil {
 		return fmt.Errorf("insufficient permissions for %s: %w\nTry running with sudo", targetDir, err)
+	}
+
+	if goos == "windows" {
+		return stageWindowsBinary(newBinaryPath, targetPath)
 	}
 
 	// Create backup
@@ -322,6 +338,98 @@ func installBinary(newBinaryPath, targetPath string) error {
 	_ = os.Remove(backupPath)
 
 	return nil
+}
+
+func stageWindowsBinary(newBinaryPath, targetPath string) error {
+	stagedPath := targetPath + ".new"
+	backupPath := targetPath + ".bak"
+
+	if err := os.Remove(stagedPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove previous staged binary: %w", err)
+	}
+
+	if err := copyFile(newBinaryPath, stagedPath); err != nil {
+		return fmt.Errorf("stage replacement binary: %w", err)
+	}
+
+	scriptPath, err := createWindowsUpdateScript(targetPath, stagedPath, backupPath)
+	if err != nil {
+		_ = os.Remove(stagedPath)
+		return err
+	}
+
+	if err := startDetachedUpdateCommand("cmd", "/C", scriptPath); err != nil {
+		_ = os.Remove(scriptPath)
+		_ = os.Remove(stagedPath)
+		return fmt.Errorf("launch deferred updater: %w", err)
+	}
+
+	return nil
+}
+
+func createWindowsUpdateScript(targetPath, stagedPath, backupPath string) (string, error) {
+	scriptFile, err := os.CreateTemp(filepath.Dir(targetPath), "nylas-update-*.cmd")
+	if err != nil {
+		return "", common.WrapCreateError("update script", err)
+	}
+
+	script := buildWindowsUpdateScript(targetPath, stagedPath, backupPath)
+	if _, err := scriptFile.WriteString(script); err != nil {
+		_ = scriptFile.Close()
+		_ = os.Remove(scriptFile.Name())
+		return "", fmt.Errorf("write update script: %w", err)
+	}
+	if err := scriptFile.Close(); err != nil {
+		_ = os.Remove(scriptFile.Name())
+		return "", fmt.Errorf("close update script: %w", err)
+	}
+
+	return scriptFile.Name(), nil
+}
+
+func buildWindowsUpdateScript(targetPath, stagedPath, backupPath string) string {
+	targetPath = escapeBatchValue(targetPath)
+	stagedPath = escapeBatchValue(stagedPath)
+	backupPath = escapeBatchValue(backupPath)
+
+	return fmt.Sprintf(`@echo off
+setlocal
+set "TARGET=%s"
+set "STAGED=%s"
+set "BACKUP=%s"
+set "REPLACED=0"
+
+:wait
+if not exist "%%TARGET%%" goto replace
+move /y "%%TARGET%%" "%%BACKUP%%" >nul 2>&1
+if errorlevel 1 (
+  ping -n 2 127.0.0.1 >nul
+  goto wait
+)
+
+:replace
+move /y "%%STAGED%%" "%%TARGET%%" >nul 2>&1
+if not errorlevel 1 set "REPLACED=1"
+if errorlevel 1 (
+  copy /y "%%STAGED%%" "%%TARGET%%" >nul 2>&1
+  if not errorlevel 1 set "REPLACED=1"
+)
+if "%%REPLACED%%"=="1" goto cleanup
+if not exist "%%BACKUP%%" goto end
+move /y "%%BACKUP%%" "%%TARGET%%" >nul 2>&1
+goto end
+
+:cleanup
+if exist "%%BACKUP%%" del /f /q "%%BACKUP%%" >nul 2>&1
+if exist "%%STAGED%%" del /f /q "%%STAGED%%" >nul 2>&1
+
+:end
+del /f /q "%%~f0" >nul 2>&1
+`, targetPath, stagedPath, backupPath)
+}
+
+func escapeBatchValue(value string) string {
+	return strings.ReplaceAll(value, "%", "%%")
 }
 
 // copyFile copies a file from src to dst.

--- a/internal/cli/update/installer_test.go
+++ b/internal/cli/update/installer_test.go
@@ -1,0 +1,126 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyChecksum(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "artifact.bin")
+	content := []byte("hello, updater")
+	require.NoError(t, os.WriteFile(filePath, content, 0o600))
+
+	sum := sha256.Sum256(content)
+	expected := hex.EncodeToString(sum[:])
+
+	ok, err := verifyChecksum(filePath, expected)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = verifyChecksum(filePath, strings.Repeat("0", len(expected)))
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestExtractFromTarGz(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "nylas.tar.gz")
+
+	f, err := os.Create(archivePath)
+	require.NoError(t, err)
+
+	gzw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gzw)
+
+	content := []byte("binary-content")
+	header := &tar.Header{
+		Name: binaryName,
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}
+	require.NoError(t, tw.WriteHeader(header))
+	_, err = tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+	require.NoError(t, f.Close())
+
+	extractedPath, err := extractFromTarGz(archivePath)
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(extractedPath) }()
+
+	extracted, err := os.ReadFile(extractedPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, extracted)
+}
+
+func TestInstallBinaryForOS_WindowsStagesDeferredReplacement(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "nylas.exe")
+	newBinaryPath := filepath.Join(dir, "nylas-new.exe")
+
+	require.NoError(t, os.WriteFile(targetPath, []byte("old-binary"), 0o755))
+	require.NoError(t, os.WriteFile(newBinaryPath, []byte("new-binary"), 0o755))
+
+	var commandName string
+	var commandArgs []string
+	oldStarter := startDetachedUpdateCommand
+	startDetachedUpdateCommand = func(name string, args ...string) error {
+		commandName = name
+		commandArgs = append([]string(nil), args...)
+		return nil
+	}
+	defer func() {
+		startDetachedUpdateCommand = oldStarter
+	}()
+
+	err := installBinaryForOS(newBinaryPath, targetPath, "windows")
+	require.NoError(t, err)
+
+	stagedPath := targetPath + ".new"
+	staged, err := os.ReadFile(stagedPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new-binary"), staged)
+
+	assert.Equal(t, "cmd", commandName)
+	require.Len(t, commandArgs, 2)
+	assert.Equal(t, "/C", commandArgs[0])
+
+	scriptBody, err := os.ReadFile(commandArgs[1])
+	require.NoError(t, err)
+	assert.Contains(t, string(scriptBody), stagedPath)
+	assert.Contains(t, string(scriptBody), targetPath)
+	assert.Contains(t, string(scriptBody), `if "%REPLACED%"=="1" goto cleanup`)
+	assert.Contains(t, string(scriptBody), `move /y "%BACKUP%" "%TARGET%" >nul 2>&1`)
+}
+
+func TestBuildWindowsUpdateScript_PreservesBackupUntilReplacementSucceeds(t *testing.T) {
+	t.Parallel()
+
+	script := buildWindowsUpdateScript(
+		`C:\Tools\100%\nylas.exe`,
+		`C:\Tools\100%\nylas.exe.new`,
+		`C:\Tools\100%\nylas.exe.bak`,
+	)
+
+	assert.Contains(t, script, `set "TARGET=C:\Tools\100%%\nylas.exe"`)
+	assert.Contains(t, script, `set "STAGED=C:\Tools\100%%\nylas.exe.new"`)
+	assert.Contains(t, script, `set "BACKUP=C:\Tools\100%%\nylas.exe.bak"`)
+	assert.Contains(t, script, `if "%REPLACED%"=="1" goto cleanup`)
+	assert.Contains(t, script, `if not exist "%BACKUP%" goto end`)
+	assert.Contains(t, script, `move /y "%BACKUP%" "%TARGET%" >nul 2>&1`)
+}

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -169,6 +169,12 @@ func runUpdate(ctx context.Context, checkOnly, force, yes bool) error {
 		return fmt.Errorf("installation failed: %w", err)
 	}
 
+	if runtime.GOOS == "windows" {
+		fmt.Printf("\nUpdate to %s has been staged.\n", latestVersion)
+		fmt.Println("Close this process and reopen Nylas CLI to complete the replacement.")
+		return nil
+	}
+
 	fmt.Printf("\nSuccessfully updated to %s!\n", latestVersion)
 	fmt.Println("Run 'nylas version' to verify.")
 


### PR DESCRIPTION
## Summary
This PR hardens several Nylas CLI correctness and reliability paths found during review of the current branch.

It fixes:
- replay of JSON request bodies on retried write requests
- dashboard multi-org login/session selection consistency
- dashboard POST response decoding for nested `data` payloads
- Windows self-update staging and rollback safety for a running executable

Jira: TW-4843
Epic: TW-4638

## Changes
- add safe request cloning/body replay for retry attempts in the Nylas HTTP client
- add regression coverage proving retried update requests resend the original JSON payload
- switch dashboard org selection to the real server-side session org during login/SSO
- stop double-unwrapping dashboard POST responses
- stage Windows updates through a deferred replacement script instead of direct in-process replacement
- preserve the backup binary until Windows replacement succeeds, and restore it on failure
- add updater regression tests for staging, rollback behavior, and batch path escaping

## Validation
- targeted regression tests for retry replay, dashboard org switching, nested response decoding, and Windows updater staging/rollback
- `make ci-full` passed 4 consecutive times

## Residual Risk / Follow-up
- the Windows updater path is unit-tested but still needs a real Windows smoke test
- dashboard org switching is covered at the helper/service level; an end-to-end CLI smoke test would be additional hardening, not a blocker

## Notes
This PR is intentionally focused on correctness and production safety rather than refactoring or behavior expansion.
