### PR TITLE
TW-4940: Harden Air setup and auth configuration flows

### DIFF
--- a/internal/air/air.go
+++ b/internal/air/air.go
@@ -113,7 +113,10 @@ The client runs locally on your machine for privacy and performance.`,
 			}
 
 			// Start the server (blocks until interrupted)
-			server := NewServer(addr)
+			server, err := NewServer(addr)
+			if err != nil {
+				return fmt.Errorf("create air server: %w", err)
+			}
 			return server.Start()
 		},
 	}

--- a/internal/air/data.go
+++ b/internal/air/data.go
@@ -134,14 +134,26 @@ type Contact struct {
 // buildMockPageData creates mock data for Phase 1 (static design).
 func buildMockPageData() PageData {
 	return PageData{
-		UserName:      "Demo User",
-		UserEmail:     "user@example.com",
-		UserAvatar:    "DU",
-		ActiveView:    "email",
-		ActiveFolder:  "inbox",
-		UnreadCount:   23,
-		SyncedAt:      time.Now(),
-		AccountsCount: 3,
+		UserName:       "Nylas",
+		UserEmail:      "nylas@example.com",
+		UserAvatar:     "N",
+		Configured:     true,
+		ClientID:       "demo-client-id",
+		Region:         "us",
+		HasAPIKey:      true,
+		DefaultGrantID: "demo-grant-nylas",
+		Provider:       "nylas",
+		ActiveView:     "email",
+		ActiveFolder:   "inbox",
+		UnreadCount:    23,
+		SyncedAt:       time.Now(),
+		AccountsCount:  1,
+		Grants: []GrantInfo{{
+			ID:        "demo-grant-nylas",
+			Email:     "nylas@example.com",
+			Provider:  "nylas",
+			IsDefault: true,
+		}},
 
 		Folders: []Folder{
 			{ID: "inbox", Name: "Inbox", Icon: "inbox", Count: 23, UnreadCount: 23, IsActive: true},

--- a/internal/air/data_test.go
+++ b/internal/air/data_test.go
@@ -20,6 +20,21 @@ func TestBuildMockPageData(t *testing.T) {
 	if data.UserAvatar == "" {
 		t.Error("expected non-empty UserAvatar")
 	}
+	if !data.Configured {
+		t.Error("expected mock page data to be configured")
+	}
+	if data.Provider != "nylas" {
+		t.Errorf("expected provider 'nylas', got %s", data.Provider)
+	}
+	if data.DefaultGrantID == "" {
+		t.Error("expected non-empty DefaultGrantID")
+	}
+	if len(data.Grants) != 1 {
+		t.Fatalf("expected exactly 1 mock grant, got %d", len(data.Grants))
+	}
+	if !data.Grants[0].IsDefault {
+		t.Error("expected mock grant to be the default")
+	}
 
 	// UI state
 	if data.ActiveView != "email" {

--- a/internal/air/handlers_ai_complete.go
+++ b/internal/air/handlers_ai_complete.go
@@ -1,11 +1,24 @@
 package air
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 )
+
+const smartComposeTimeout = 5 * time.Second
+
+var runSmartComposeCommand = func(ctx context.Context, prompt string) ([]byte, error) {
+	//nolint:gosec // G204: Command is hardcoded "claude" binary, prompt is passed as a single argument.
+	cmd := exec.Command("claude", "-p", prompt)
+	return runCommandOutput(ctx, cmd)
+}
 
 // CompleteRequest represents a smart compose request
 type CompleteRequest struct {
@@ -41,7 +54,7 @@ func (s *Server) handleAIComplete(w http.ResponseWriter, r *http.Request) {
 		req.MaxLength = 100
 	}
 
-	suggestion := getAICompletion(req.Text, req.MaxLength)
+	suggestion := getAICompletion(r.Context(), req.Text, req.MaxLength)
 
 	w.Header().Set("Content-Type", "application/json")
 	resp := CompleteResponse{
@@ -54,12 +67,13 @@ func (s *Server) handleAIComplete(w http.ResponseWriter, r *http.Request) {
 }
 
 // getAICompletion gets completion from Claude via CLI
-func getAICompletion(text string, maxLen int) string {
+func getAICompletion(ctx context.Context, text string, maxLen int) string {
 	prompt := buildCompletionPrompt(text, maxLen)
 
-	//nolint:gosec // G204: Command is hardcoded "claude" binary, prompt is user-controlled but safe for CLI arg
-	cmd := exec.Command("claude", "-p", prompt)
-	output, err := cmd.Output()
+	ctx, cancel := context.WithTimeout(ctx, smartComposeTimeout)
+	defer cancel()
+
+	output, err := runSmartComposeCommand(ctx, prompt)
 	if err != nil {
 		return ""
 	}
@@ -86,13 +100,47 @@ func buildCompletionPrompt(text string, maxLen int) string {
 		"Complete the following email text naturally.",
 		"Only provide the completion, not the original text.",
 		"Keep it concise and professional.",
-		"Maximum " + string(rune(maxLen)) + " characters.",
+		fmt.Sprintf("Maximum %s characters.", strconv.Itoa(maxLen)),
 		"",
 		"Text to complete:",
 		text,
 		"",
 		"Completion:",
 	}, "\n")
+}
+
+func runCommandOutput(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	configureChildProcessGroup(cmd)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-waitCh:
+		if err != nil {
+			return nil, err
+		}
+		return stdout.Bytes(), nil
+	case <-ctx.Done():
+		_ = killCommandTree(cmd)
+		<-waitCh
+		return nil, ctx.Err()
+	}
 }
 
 // NLSearchRequest represents a natural language search request

--- a/internal/air/handlers_ai_complete_test.go
+++ b/internal/air/handlers_ai_complete_test.go
@@ -2,9 +2,11 @@ package air
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -275,5 +277,70 @@ func TestBuildCompletionPrompt(t *testing.T) {
 
 	if len(prompt) < len(text) {
 		t.Error("prompt should include the input text")
+	}
+
+	if !strings.Contains(prompt, "Maximum 50 characters.") {
+		t.Fatalf("expected prompt to include max length, got %q", prompt)
+	}
+}
+
+func TestGetAICompletion_UsesTimeoutAndTruncatesOutput(t *testing.T) {
+	originalRunner := runSmartComposeCommand
+	t.Cleanup(func() {
+		runSmartComposeCommand = originalRunner
+	})
+
+	runSmartComposeCommand = func(ctx context.Context, prompt string) ([]byte, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("expected smart compose runner to receive a deadline")
+		}
+		if !strings.Contains(prompt, "Maximum 10 characters.") {
+			t.Fatalf("expected prompt to contain max length, got %q", prompt)
+		}
+		return []byte("hello world again"), nil
+	}
+
+	suggestion := getAICompletion(context.Background(), "Hello", 10)
+	if suggestion != "hello" {
+		t.Fatalf("expected truncated suggestion %q, got %q", "hello", suggestion)
+	}
+}
+
+func TestHandleAIComplete_ReturnsEmptySuggestionWhenRequestContextIsCanceled(t *testing.T) {
+	originalRunner := runSmartComposeCommand
+	t.Cleanup(func() {
+		runSmartComposeCommand = originalRunner
+	})
+
+	runSmartComposeCommand = func(ctx context.Context, prompt string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	server := &Server{}
+
+	body := CompleteRequest{Text: "Draft a reply", MaxLength: 100}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/complete", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	server.handleAIComplete(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp CompleteResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Suggestion != "" {
+		t.Fatalf("expected empty suggestion when command context is canceled, got %q", resp.Suggestion)
 	}
 }

--- a/internal/air/handlers_ai_complete_unix_test.go
+++ b/internal/air/handlers_ai_complete_unix_test.go
@@ -1,0 +1,94 @@
+//go:build !windows
+
+package air
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRunCommandOutput_KillsChildProcessGroupOnCancel(t *testing.T) {
+	t.Parallel()
+
+	pidFile := t.TempDir() + "/child.pid"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.Command("sh", "-c", `sleep 30 & echo $! > "$CHILD_PID_FILE"; wait`)
+	cmd.Env = append(os.Environ(), "CHILD_PID_FILE="+pidFile)
+
+	doneCh := make(chan error, 1)
+	go func() {
+		_, err := runCommandOutput(ctx, cmd)
+		doneCh <- err
+	}()
+
+	childPID := waitForChildPID(t, pidFile)
+	cancel()
+
+	select {
+	case err := <-doneCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for command cancellation")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(childPID, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Fatalf("expected child process %d to be terminated with its parent process group", childPID)
+}
+
+func TestRunCommandOutput_DoesNotStartWhenContextAlreadyCanceled(t *testing.T) {
+	t.Parallel()
+
+	sentinel := t.TempDir() + "/started"
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := exec.Command("sh", "-c", `touch "$SENTINEL"`)
+	cmd.Env = append(os.Environ(), "SENTINEL="+sentinel)
+
+	_, err := runCommandOutput(ctx, cmd)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+
+	if _, statErr := os.Stat(sentinel); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected command not to start, stat error=%v", statErr)
+	}
+}
+
+func waitForChildPID(t *testing.T, pidFile string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err == nil && len(strings.TrimSpace(string(data))) > 0 {
+			pid, convErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if convErr != nil {
+				t.Fatalf("parse child pid: %v", convErr)
+			}
+			return pid
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for child pid file %s", pidFile)
+	return 0
+}

--- a/internal/air/handlers_cache.go
+++ b/internal/air/handlers_cache.go
@@ -472,30 +472,10 @@ func (s *Server) updateCacheSettings(w http.ResponseWriter, r *http.Request) {
 
 // getCurrentUserEmail returns the current user's email address.
 func (s *Server) getCurrentUserEmail() string {
-	if s.grantStore == nil {
-		return ""
-	}
-
-	defaultID, err := s.grantStore.GetDefaultGrant()
+	grant, err := s.resolveDefaultGrantInfo()
 	if err != nil {
 		return ""
 	}
 
-	grants, err := s.grantStore.ListGrants()
-	if err != nil {
-		return ""
-	}
-
-	for _, g := range grants {
-		if g.ID == defaultID {
-			return g.Email
-		}
-	}
-
-	// Fall back to first grant
-	if len(grants) > 0 {
-		return grants[0].Email
-	}
-
-	return ""
+	return grant.Email
 }

--- a/internal/air/handlers_config.go
+++ b/internal/air/handlers_config.go
@@ -32,18 +32,15 @@ func (s *Server) handleConfigStatus(w http.ResponseWriter, r *http.Request) {
 	// Use s.hasAPIKey which is set during server initialization from keyring
 	hasAPIKey := s.hasAPIKey || status.HasAPIKey
 
-	// Get grant count from grant store (more accurate than config file)
-	grantCount := status.GrantCount
-	if grants, err := s.grantStore.ListGrants(); err == nil {
+	// Air is only configured once it has at least one supported account.
+	grantCount := 0
+	if grants, err := s.listSupportedGrants(); err == nil {
 		grantCount = len(grants)
 	}
 
-	// Get default grant from grant store
 	defaultGrant := status.DefaultGrant
-	if defaultGrant == "" {
-		if grantID, err := s.grantStore.GetDefaultGrant(); err == nil {
-			defaultGrant = grantID
-		}
+	if grant, err := s.resolveDefaultGrantInfo(); err == nil {
+		defaultGrant = grant.ID
 	}
 
 	resp := ConfigStatusResponse{
@@ -84,18 +81,9 @@ func (s *Server) handleListGrants(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	defaultID, _ := s.grantStore.GetDefaultGrant()
-
-	// If default grant is not a supported provider, pick the first supported account as default
-	defaultIsSupported := false
-	for _, g := range grantList {
-		if g.ID == defaultID {
-			defaultIsSupported = true
-			break
-		}
-	}
-	if !defaultIsSupported && len(grantList) > 0 {
-		defaultID = grantList[0].ID
+	defaultID := ""
+	if grant, err := s.resolveDefaultGrantInfo(); err == nil {
+		defaultID = grant.ID
 	}
 
 	writeJSON(w, http.StatusOK, GrantsResponse{
@@ -151,7 +139,23 @@ func (s *Server) handleSetDefaultGrant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.grantStore.SetDefaultGrant(req.GrantID); err != nil {
+	selectedGrant, err := s.grantStore.GetGrant(req.GrantID)
+	if err != nil || selectedGrant == nil {
+		writeJSON(w, http.StatusNotFound, SetDefaultGrantResponse{
+			Success: false,
+			Error:   "Grant not found",
+		})
+		return
+	}
+	if !selectedGrant.Provider.IsSupportedByAir() {
+		writeJSON(w, http.StatusBadRequest, SetDefaultGrantResponse{
+			Success: false,
+			Error:   "Grant provider is not supported by Air",
+		})
+		return
+	}
+
+	if err := s.setDefaultGrant(req.GrantID); err != nil {
 		writeJSON(w, http.StatusInternalServerError, SetDefaultGrantResponse{
 			Success: false,
 			Error:   "Failed to set default grant: " + err.Error(),

--- a/internal/air/handlers_config_test.go
+++ b/internal/air/handlers_config_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	configadapter "github.com/nylas/cli/internal/adapters/config"
+	keyringadapter "github.com/nylas/cli/internal/adapters/keyring"
+	authapp "github.com/nylas/cli/internal/app/auth"
 	"github.com/nylas/cli/internal/domain"
 )
 
@@ -209,6 +212,130 @@ func TestHandleListGrants_IncludesNylasProviders(t *testing.T) {
 
 	if resp.DefaultGrant != "grant-nylas" {
 		t.Errorf("expected default grant 'grant-nylas', got %s", resp.DefaultGrant)
+	}
+}
+
+func TestHandleListGrants_UsesSupportedFallbackWithoutMutatingDefault(t *testing.T) {
+	t.Parallel()
+
+	configStore := configadapter.NewMockConfigStore()
+	configStore.SetConfig(&domain.Config{Region: "us", DefaultGrant: "grant-imap"})
+	grantStore := &testGrantStore{
+		grants: []domain.GrantInfo{
+			{ID: "grant-imap", Email: "imap@example.com", Provider: domain.ProviderIMAP},
+			{ID: "grant-google", Email: "google@example.com", Provider: domain.ProviderGoogle},
+		},
+		defaultGrant: "grant-imap",
+	}
+	server := &Server{
+		grantStore:  grantStore,
+		configStore: configStore,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/grants", nil)
+	w := httptest.NewRecorder()
+
+	server.handleListGrants(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp GrantsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.DefaultGrant != "grant-google" {
+		t.Fatalf("expected supported default grant %q, got %q", "grant-google", resp.DefaultGrant)
+	}
+	if grantStore.defaultGrant != "grant-imap" {
+		t.Fatalf("expected stored keyring default grant to remain %q, got %q", "grant-imap", grantStore.defaultGrant)
+	}
+
+	cfg, err := configStore.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.DefaultGrant != "grant-imap" {
+		t.Fatalf("expected config default grant to remain %q, got %q", "grant-imap", cfg.DefaultGrant)
+	}
+}
+
+func TestHandleSetDefaultGrant_RejectsUnsupportedProviders(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{
+		grantStore: &testGrantStore{
+			grants: []domain.GrantInfo{
+				{ID: "grant-imap", Email: "imap@example.com", Provider: domain.ProviderIMAP},
+			},
+		},
+		configStore: configadapter.NewMockConfigStore(),
+	}
+
+	body := `{"grant_id":"grant-imap"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/grants/default", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.handleSetDefaultGrant(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+
+	var resp SetDefaultGrantResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !strings.Contains(resp.Error, "not supported") {
+		t.Fatalf("expected unsupported-provider error, got %q", resp.Error)
+	}
+}
+
+func TestBuildPageData_UsesResolvedSupportedDefaultGrantWithoutPersistingIt(t *testing.T) {
+	t.Parallel()
+
+	configStore := configadapter.NewMockConfigStore()
+	configStore.SetConfig(&domain.Config{Region: "us", DefaultGrant: "grant-imap"})
+	secretStore := keyringadapter.NewMockSecretStore()
+	grantStore := &testGrantStore{
+		grants: []domain.GrantInfo{
+			{ID: "grant-imap", Email: "imap@example.com", Provider: domain.ProviderIMAP},
+			{ID: "grant-google", Email: "google@example.com", Provider: domain.ProviderGoogle},
+		},
+		defaultGrant: "grant-imap",
+	}
+
+	server := &Server{
+		configSvc:   authapp.NewConfigService(configStore, secretStore),
+		configStore: configStore,
+		grantStore:  grantStore,
+		hasAPIKey:   true,
+	}
+
+	data := server.buildPageData()
+
+	if !data.Configured {
+		t.Fatal("expected Air to be configured when a supported grant is available")
+	}
+	if data.DefaultGrantID != "grant-google" {
+		t.Fatalf("expected resolved default grant %q, got %q", "grant-google", data.DefaultGrantID)
+	}
+	if data.UserEmail != "google@example.com" {
+		t.Fatalf("expected resolved user email %q, got %q", "google@example.com", data.UserEmail)
+	}
+	if grantStore.defaultGrant != "grant-imap" {
+		t.Fatalf("expected stored grant store default to remain %q, got %q", "grant-imap", grantStore.defaultGrant)
+	}
+
+	cfg, err := configStore.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.DefaultGrant != "grant-imap" {
+		t.Fatalf("expected config default grant to remain %q, got %q", "grant-imap", cfg.DefaultGrant)
 	}
 }
 

--- a/internal/air/integration_middleware_test.go
+++ b/internal/air/integration_middleware_test.go
@@ -142,19 +142,23 @@ func TestIntegration_Middleware_CORS(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := CORSMiddleware(mux)
+	handler := HostValidationMiddleware(CORSMiddleware(mux))
 
 	// Test regular request
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Host = "localhost:7365"
+	req.Header.Set("Origin", "http://localhost:7365")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
-		t.Error("expected Access-Control-Allow-Origin: *")
+	if w.Header().Get("Access-Control-Allow-Origin") != "http://localhost:7365" {
+		t.Error("expected reflected same-origin Access-Control-Allow-Origin header")
 	}
 
 	// Test OPTIONS preflight
 	reqOptions := httptest.NewRequest(http.MethodOptions, "/api/test", nil)
+	reqOptions.Host = "localhost:7365"
+	reqOptions.Header.Set("Origin", "http://localhost:7365")
 	wOptions := httptest.NewRecorder()
 	handler.ServeHTTP(wOptions, reqOptions)
 
@@ -164,6 +168,16 @@ func TestIntegration_Middleware_CORS(t *testing.T) {
 
 	if wOptions.Header().Get("Access-Control-Allow-Methods") == "" {
 		t.Error("OPTIONS should include Access-Control-Allow-Methods")
+	}
+
+	reqCrossOrigin := httptest.NewRequest(http.MethodOptions, "/api/test", nil)
+	reqCrossOrigin.Host = "localhost:7365"
+	reqCrossOrigin.Header.Set("Origin", "https://evil.example")
+	wCrossOrigin := httptest.NewRecorder()
+	handler.ServeHTTP(wCrossOrigin, reqCrossOrigin)
+
+	if wCrossOrigin.Code != http.StatusForbidden {
+		t.Errorf("cross-origin OPTIONS should return 403, got %d", wCrossOrigin.Code)
 	}
 
 	t.Log("✓ CORS headers working correctly")
@@ -203,13 +217,17 @@ func TestIntegration_Middleware_FullStack(t *testing.T) {
 	})
 
 	// Apply full middleware stack (same order as server.go)
-	handler := CORSMiddleware(
-		SecurityHeadersMiddleware(
-			CompressionMiddleware(
-				CacheMiddleware(
-					PerformanceMonitoringMiddleware(mux)))))
+	handler := HostValidationMiddleware(
+		CORSMiddleware(
+			OriginProtectionMiddleware(
+				SecurityHeadersMiddleware(
+					CompressionMiddleware(
+						CacheMiddleware(
+							PerformanceMonitoringMiddleware(mux)))))))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Host = "localhost:7365"
+	req.Header.Set("Origin", "http://localhost:7365")
 	req.Header.Set("Accept-Encoding", "gzip")
 	w := httptest.NewRecorder()
 
@@ -217,7 +235,7 @@ func TestIntegration_Middleware_FullStack(t *testing.T) {
 
 	// Verify all middleware features are active
 	checks := map[string]func() bool{
-		"CORS":        func() bool { return w.Header().Get("Access-Control-Allow-Origin") == "*" },
+		"CORS":        func() bool { return w.Header().Get("Access-Control-Allow-Origin") == "http://localhost:7365" },
 		"Security":    func() bool { return w.Header().Get("X-Frame-Options") == "SAMEORIGIN" },
 		"Compression": func() bool { return w.Header().Get("Content-Encoding") == "gzip" },
 		"Cache":       func() bool { return w.Header().Get("Cache-Control") == "no-cache, no-store, must-revalidate" },

--- a/internal/air/middleware.go
+++ b/internal/air/middleware.go
@@ -3,7 +3,9 @@ package air
 import (
 	"compress/gzip"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -205,22 +207,113 @@ func MethodOverrideMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// CORSMiddleware adds CORS headers for local development.
-// This allows the frontend to make API requests.
+// HostValidationMiddleware rejects requests that do not target an explicit
+// loopback Air host.
+func HostValidationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isAllowedAirHost(r.Host) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// CORSMiddleware reflects CORS headers only for the Air origin. Cross-origin
+// sites should not be able to read responses from the local Air API.
 func CORSMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Allow requests from same origin (localhost)
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-HTTP-Method-Override")
-		w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		if origin != "" && isAllowedBrowserOrigin(origin, r.Host) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-HTTP-Method-Override")
+			w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
+			w.Header().Set("Vary", "Origin")
+		}
 
-		// Handle preflight requests
-		if r.Method == "OPTIONS" {
+		if r.Method == http.MethodOptions {
+			if origin == "" || !isAllowedBrowserOrigin(origin, r.Host) {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// OriginProtectionMiddleware rejects state-changing requests that do not
+// originate from the active Air origin.
+func OriginProtectionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !requiresSameOriginProtection(r.Method) || requestMatchesAirOrigin(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		http.Error(w, "Forbidden", http.StatusForbidden)
+	})
+}
+
+func requiresSameOriginProtection(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return false
+	default:
+		return true
+	}
+}
+
+func requestMatchesAirOrigin(r *http.Request) bool {
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
+		return isAllowedBrowserOrigin(origin, r.Host)
+	}
+	if referer := strings.TrimSpace(r.Header.Get("Referer")); referer != "" {
+		return isAllowedBrowserOrigin(referer, r.Host)
+	}
+	return false
+}
+
+func isAllowedBrowserOrigin(rawOrigin, requestHost string) bool {
+	if !isAllowedAirHost(requestHost) {
+		return false
+	}
+
+	parsed, err := url.Parse(rawOrigin)
+	if err != nil {
+		return false
+	}
+	if parsed.Host == "" {
+		return false
+	}
+	if parsed.Scheme != "http" {
+		return false
+	}
+	if !isAllowedAirHost(parsed.Host) {
+		return false
+	}
+
+	return strings.EqualFold(parsed.Host, requestHost)
+}
+
+func isAllowedAirHost(requestHost string) bool {
+	host := requestHost
+	if parsedHost, _, err := net.SplitHostPort(requestHost); err == nil {
+		host = parsedHost
+	}
+
+	host = strings.Trim(strings.TrimSpace(host), "[]")
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/internal/air/middleware_test.go
+++ b/internal/air/middleware_test.go
@@ -309,7 +309,7 @@ func TestMethodOverrideMiddleware_OnlyOverridesPOST(t *testing.T) {
 }
 
 // TestCORSMiddleware_SetsHeaders tests CORS headers.
-func TestCORSMiddleware_SetsHeaders(t *testing.T) {
+func TestCORSMiddleware_ReflectsSameOrigin(t *testing.T) {
 	t.Parallel()
 
 	handler := CORSMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -317,6 +317,8 @@ func TestCORSMiddleware_SetsHeaders(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "localhost:7365"
+	req.Header.Set("Origin", "http://localhost:7365")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -325,9 +327,10 @@ func TestCORSMiddleware_SetsHeaders(t *testing.T) {
 		header   string
 		expected string
 	}{
-		{"Access-Control-Allow-Origin", "*"},
+		{"Access-Control-Allow-Origin", "http://localhost:7365"},
 		{"Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS"},
 		{"Access-Control-Max-Age", "86400"},
+		{"Vary", "Origin"},
 	}
 
 	for _, tt := range tests {
@@ -339,7 +342,7 @@ func TestCORSMiddleware_SetsHeaders(t *testing.T) {
 }
 
 // TestCORSMiddleware_HandlesPreflightRequests tests OPTIONS preflight.
-func TestCORSMiddleware_HandlesPreflightRequests(t *testing.T) {
+func TestCORSMiddleware_RejectsCrossOriginPreflight(t *testing.T) {
 	t.Parallel()
 
 	handlerCalled := false
@@ -349,16 +352,89 @@ func TestCORSMiddleware_HandlesPreflightRequests(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodOptions, "/test", nil)
+	req.Host = "localhost:7365"
+	req.Header.Set("Origin", "https://evil.example")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("expected status 204 for OPTIONS, got %d", w.Code)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected status 403 for cross-origin OPTIONS, got %d", w.Code)
 	}
 
 	if handlerCalled {
 		t.Error("expected handler not to be called for OPTIONS preflight")
+	}
+}
+
+func TestHostValidationMiddleware_RejectsNonLoopbackHost(t *testing.T) {
+	t.Parallel()
+
+	handlerCalled := false
+	handler := HostValidationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "evil.example:7365"
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", w.Code)
+	}
+	if handlerCalled {
+		t.Fatal("expected non-loopback host to be rejected before handler execution")
+	}
+}
+
+func TestOriginProtectionMiddleware_AllowsSameOriginMutation(t *testing.T) {
+	t.Parallel()
+
+	handlerCalled := false
+	handler := OriginProtectionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Host = "localhost:7365"
+	req.Header.Set("Origin", "http://localhost:7365")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if !handlerCalled {
+		t.Error("expected same-origin POST to reach the handler")
+	}
+}
+
+func TestOriginProtectionMiddleware_BlocksCrossOriginMutation(t *testing.T) {
+	t.Parallel()
+
+	handlerCalled := false
+	handler := OriginProtectionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Host = "localhost:7365"
+	req.Header.Set("Origin", "https://evil.example")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected status 403, got %d", w.Code)
+	}
+	if handlerCalled {
+		t.Error("expected cross-origin POST to be rejected before handler execution")
 	}
 }
 
@@ -368,22 +444,26 @@ func TestMiddlewareChain_OrderMatters(t *testing.T) {
 
 	var executionOrder []string
 
-	handler := CORSMiddleware(
-		SecurityHeadersMiddleware(
-			CompressionMiddleware(
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					executionOrder = append(executionOrder, "handler")
-					w.WriteHeader(http.StatusOK)
-				}))))
+	handler := HostValidationMiddleware(
+		CORSMiddleware(
+			OriginProtectionMiddleware(
+				SecurityHeadersMiddleware(
+					CompressionMiddleware(
+						http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							executionOrder = append(executionOrder, "handler")
+							w.WriteHeader(http.StatusOK)
+						}))))))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "localhost:7365"
+	req.Header.Set("Origin", "http://localhost:7365")
 	req.Header.Set("Accept-Encoding", "gzip")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
 
 	// Verify CORS headers (outermost middleware)
-	if w.Header().Get("Access-Control-Allow-Origin") != "*" {
+	if w.Header().Get("Access-Control-Allow-Origin") != "http://localhost:7365" {
 		t.Error("expected CORS headers to be set")
 	}
 

--- a/internal/air/server_lifecycle.go
+++ b/internal/air/server_lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/nylas/cli/internal/adapters/config"
@@ -16,9 +17,20 @@ import (
 )
 
 // NewServer creates a new Air server.
-func NewServer(addr string) *Server {
+func NewServer(addr string) (*Server, error) {
+	return newServer(addr, keyring.NewSecretStore)
+}
+
+func newServer(addr string, secretStoreFactory func(string) (ports.SecretStore, error)) (*Server, error) {
+	if airTestModeEnabled() {
+		return NewDemoServer(addr), nil
+	}
+
 	configStore := config.NewDefaultFileStore()
-	secretStore, _ := keyring.NewSecretStore(config.DefaultConfigDir())
+	secretStore, err := secretStoreFactory(config.DefaultConfigDir())
+	if err != nil {
+		return nil, fmt.Errorf("initialize secret store: %w", err)
+	}
 	grantStore := keyring.NewGrantStore(secretStore)
 	configSvc := authapp.NewConfigService(configStore, secretStore)
 
@@ -66,7 +78,7 @@ func NewServer(addr string) *Server {
 		offlineQueues: make(map[string]*cache.OfflineQueue),
 		syncStopCh:    make(chan struct{}),
 		isOnline:      true,
-	}
+	}, nil
 }
 
 // initCacheRuntime initializes runtime cache components for the server.
@@ -111,6 +123,11 @@ func NewDemoServer(addr string) *Server {
 		demoMode:  true,
 		templates: tmpl,
 	}
+}
+
+func airTestModeEnabled() bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv("AIR_TEST_MODE")))
+	return value == "1" || value == "true" || value == "yes"
 }
 
 // Start starts the HTTP server.
@@ -278,14 +295,17 @@ func (s *Server) Start() error {
 		s.startBackgroundSync()
 	}
 
-	// Apply middleware chain for performance and security
-	// Order matters: CORS → Security → Compression → Cache → Monitoring → MethodOverride → Handler
-	handler := CORSMiddleware(
-		SecurityHeadersMiddleware(
-			CompressionMiddleware(
-				CacheMiddleware(
-					PerformanceMonitoringMiddleware(
-						MethodOverrideMiddleware(mux))))))
+	// Apply middleware chain for performance and security.
+	// Order matters: HostValidation → CORS → OriginProtection → Security →
+	// Compression → Cache → Monitoring → MethodOverride → Handler
+	handler := HostValidationMiddleware(
+		CORSMiddleware(
+			OriginProtectionMiddleware(
+				SecurityHeadersMiddleware(
+					CompressionMiddleware(
+						CacheMiddleware(
+							PerformanceMonitoringMiddleware(
+								MethodOverrideMiddleware(mux))))))))
 
 	server := &http.Server{
 		Addr:              s.addr,

--- a/internal/air/server_modules_test.go
+++ b/internal/air/server_modules_test.go
@@ -1,11 +1,13 @@
 package air
 
 import (
+	"errors"
 	"html/template"
 	"testing"
 	"time"
 
 	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/ports"
 )
 
 // =============================================================================
@@ -244,7 +246,10 @@ func TestEventParticipantsToStrings(t *testing.T) {
 func TestNewServer(t *testing.T) {
 	t.Parallel()
 
-	server := NewServer(":8080")
+	server, err := NewServer(":8080")
+	if err != nil {
+		t.Fatalf("expected no error creating server, got %v", err)
+	}
 
 	if server == nil {
 		t.Fatal("expected non-nil server")
@@ -282,10 +287,47 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
+func TestNewServer_UsesDemoServerWhenAirTestModeEnabled(t *testing.T) {
+	t.Setenv("AIR_TEST_MODE", "true")
+
+	server, err := NewServer(":8080")
+	if err != nil {
+		t.Fatalf("expected no error creating test-mode server, got %v", err)
+	}
+
+	if server == nil {
+		t.Fatal("expected non-nil server")
+	}
+	if !server.demoMode {
+		t.Error("expected AIR_TEST_MODE server to run in demo mode")
+	}
+	if server.configSvc != nil {
+		t.Error("expected demo-mode server to skip config initialization")
+	}
+}
+
+func TestNewServer_ReturnsErrorWhenSecretStoreInitializationFails(t *testing.T) {
+	t.Parallel()
+
+	server, err := newServer(":8080", func(string) (ports.SecretStore, error) {
+		return nil, errors.New("boom")
+	})
+
+	if err == nil {
+		t.Fatal("expected error when secret store initialization fails")
+	}
+	if server != nil {
+		t.Fatal("expected nil server when initialization fails")
+	}
+}
+
 func TestServer_IsOnline_SetOnline(t *testing.T) {
 	t.Parallel()
 
-	server := NewServer(":8080")
+	server, err := NewServer(":8080")
+	if err != nil {
+		t.Fatalf("expected no error creating server, got %v", err)
+	}
 
 	// Initial state
 	if !server.IsOnline() {
@@ -388,7 +430,10 @@ func TestTemplateFuncs_SafeHTML(t *testing.T) {
 func TestBuildPageData_NonDemoMode(t *testing.T) {
 	t.Parallel()
 
-	server := NewServer(":8080")
+	server, err := NewServer(":8080")
+	if err != nil {
+		t.Fatalf("expected no error creating server, got %v", err)
+	}
 	data := server.buildPageData()
 
 	// In non-demo mode with no grants, should have nil data arrays

--- a/internal/air/server_stores.go
+++ b/internal/air/server_stores.go
@@ -2,10 +2,12 @@ package air
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/nylas/cli/internal/air/cache"
+	authapp "github.com/nylas/cli/internal/app/auth"
 	"github.com/nylas/cli/internal/domain"
 )
 
@@ -122,37 +124,85 @@ func (s *Server) withOfflineQueue(email string, fn func(*cache.OfflineQueue) err
 	return fn(queue)
 }
 
+func (s *Server) listSupportedGrants() ([]domain.GrantInfo, error) {
+	if s.grantStore == nil {
+		return nil, domain.ErrGrantNotFound
+	}
+
+	grants, err := s.grantStore.ListGrants()
+	if err != nil {
+		return nil, err
+	}
+
+	supported := make([]domain.GrantInfo, 0, len(grants))
+	for _, grant := range grants {
+		if grant.Provider.IsSupportedByAir() {
+			supported = append(supported, grant)
+		}
+	}
+
+	return supported, nil
+}
+
+func (s *Server) setDefaultGrant(grantID string) error {
+	if s.grantStore == nil {
+		return domain.ErrGrantNotFound
+	}
+
+	return authapp.PersistDefaultGrant(s.configStore, s.grantStore, grantID)
+}
+
+func (s *Server) resolveDefaultGrantInfo() (domain.GrantInfo, error) {
+	supported, err := s.listSupportedGrants()
+	if err != nil {
+		return domain.GrantInfo{}, err
+	}
+	if len(supported) == 0 {
+		return domain.GrantInfo{}, domain.ErrGrantNotFound
+	}
+
+	defaultID, err := s.grantStore.GetDefaultGrant()
+	switch {
+	case err == nil:
+		for _, grant := range supported {
+			if grant.ID == defaultID {
+				return grant, nil
+			}
+		}
+	case !errors.Is(err, domain.ErrNoDefaultGrant):
+		return domain.GrantInfo{}, err
+	}
+
+	selected := supported[0]
+	return selected, nil
+}
+
 // requireDefaultGrant gets the default grant ID, writing an error response if not available.
 // Returns the grant ID and true if successful, or empty string and false if error written.
 // Callers should return immediately when ok is false.
 func (s *Server) requireDefaultGrant(w http.ResponseWriter) (grantID string, ok bool) {
-	grantID, err := s.grantStore.GetDefaultGrant()
-	if err != nil || grantID == "" {
+	grant, err := s.resolveDefaultGrantInfo()
+	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": "No default account. Please select an account first.",
+			"error": "No supported Air account is configured. Please select a Google, Microsoft, or Nylas account first.",
 		})
 		return "", false
 	}
-	return grantID, true
+	return grant.ID, true
 }
 
 // requireDefaultGrantInfo gets the default grant info, writing an error response if not available.
 // Returns the grant info and true if successful, or an empty grant and false if error written.
 func (s *Server) requireDefaultGrantInfo(w http.ResponseWriter) (grant domain.GrantInfo, ok bool) {
-	grantID, ok := s.requireDefaultGrant(w)
-	if !ok {
-		return domain.GrantInfo{}, false
-	}
-
-	info, err := s.grantStore.GetGrant(grantID)
-	if err != nil || info == nil {
+	info, err := s.resolveDefaultGrantInfo()
+	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": "Default account is no longer available. Please choose another account.",
+			"error": "No supported Air account is configured. Please choose another account.",
 		})
 		return domain.GrantInfo{}, false
 	}
 
-	return *info, true
+	return info, true
 }
 
 // getEmailStore returns the email store for the given email account.

--- a/internal/air/server_template.go
+++ b/internal/air/server_template.go
@@ -4,8 +4,6 @@ import (
 	"html/template"
 	"net/http"
 	"sync"
-
-	"github.com/nylas/cli/internal/domain"
 )
 
 // handleIndex renders the main page.
@@ -60,60 +58,31 @@ func (s *Server) buildPageData() PageData {
 	}
 
 	// Get real grants filtered to providers supported by Air.
-	// Also used to determine if configured (need API key AND at least one grant)
-	grants, err := s.grantStore.ListGrants()
-	hasGrants := err == nil && len(grants) > 0
-	data.Configured = data.HasAPIKey && hasGrants
+	supportedGrants, err := s.listSupportedGrants()
+	data.Configured = data.HasAPIKey && err == nil && len(supportedGrants) > 0
 
-	if hasGrants {
-		// Filter to supported providers only
-		var supportedGrants []domain.GrantInfo
-		for _, g := range grants {
-			if g.Provider.IsSupportedByAir() {
-				supportedGrants = append(supportedGrants, g)
-			}
+	if len(supportedGrants) > 0 {
+		defaultGrant, defaultErr := s.resolveDefaultGrantInfo()
+
+		if defaultErr == nil {
+			data.UserEmail = defaultGrant.Email
+			data.UserName = extractName(defaultGrant.Email)
+			data.UserAvatar = initials(defaultGrant.Email)
+			data.DefaultGrantID = defaultGrant.ID
+			data.Provider = string(defaultGrant.Provider)
 		}
 
-		if len(supportedGrants) > 0 {
-			// Get default grant ID
-			defaultID, _ := s.grantStore.GetDefaultGrant()
-
-			// Check if default is a supported provider, otherwise use first supported account
-			defaultIsSupported := false
-			for _, g := range supportedGrants {
-				if g.ID == defaultID {
-					defaultIsSupported = true
-					break
-				}
-			}
-			if !defaultIsSupported {
-				defaultID = supportedGrants[0].ID
-			}
-
-			// Find default grant info
-			for _, g := range supportedGrants {
-				if g.ID == defaultID {
-					data.UserEmail = g.Email
-					data.UserName = extractName(g.Email)
-					data.UserAvatar = initials(g.Email)
-					data.DefaultGrantID = g.ID
-					data.Provider = string(g.Provider)
-					break
-				}
-			}
-
-			// Build grants list for UI (supported providers only)
-			data.Grants = make([]GrantInfo, 0, len(supportedGrants))
-			for _, g := range supportedGrants {
-				data.Grants = append(data.Grants, GrantInfo{
-					ID:        g.ID,
-					Email:     g.Email,
-					Provider:  string(g.Provider),
-					IsDefault: g.ID == defaultID,
-				})
-			}
-			data.AccountsCount = len(supportedGrants)
+		// Build grants list for UI (supported providers only)
+		data.Grants = make([]GrantInfo, 0, len(supportedGrants))
+		for _, g := range supportedGrants {
+			data.Grants = append(data.Grants, GrantInfo{
+				ID:        g.ID,
+				Email:     g.Email,
+				Provider:  string(g.Provider),
+				IsDefault: defaultErr == nil && g.ID == defaultGrant.ID,
+			})
 		}
+		data.AccountsCount = len(supportedGrants)
 	}
 
 	return data

--- a/internal/air/smart_compose_process_unix.go
+++ b/internal/air/smart_compose_process_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package air
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func configureChildProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}
+
+func killCommandTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+
+	return nil
+}

--- a/internal/air/smart_compose_process_windows.go
+++ b/internal/air/smart_compose_process_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package air
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+func configureChildProcessGroup(cmd *exec.Cmd) {}
+
+func killCommandTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	taskkill := exec.Command("taskkill", "/PID", strconv.Itoa(cmd.Process.Pid), "/T", "/F")
+	if err := taskkill.Run(); err == nil {
+		return nil
+	}
+
+	return cmd.Process.Kill()
+}

--- a/internal/air/static/js/email-folders.js
+++ b/internal/air/static/js/email-folders.js
@@ -1,5 +1,7 @@
 /* Email Folders - Folder management */
-Object.assign(EmailListManager, {
+const EmailFoldersManager = typeof EmailListManager !== 'undefined' ? EmailListManager : {};
+
+Object.assign(EmailFoldersManager, {
 async loadFolders() {
     try {
         const data = await AirAPI.getFolders();
@@ -23,13 +25,10 @@ findFolderByName(name) {
     return this.folders.find(f => (f.name || '').toLowerCase() === lowerName);
 },
 
-renderFolders(folders) {
-    const folderList = document.getElementById('folderList') || document.querySelector('.folder-group');
-    if (!folderList || folders.length === 0) return;
-
+getVisibleFolders(folders) {
     // Primary folder names to show directly (in order)
     // Use names instead of IDs to support both Google (ID=INBOX) and Microsoft (ID=long-string, name=Inbox)
-    const primaryFolderNames = ['inbox', 'starred', 'sent', 'sent items', 'draft', 'drafts', 'trash', 'deleted items', 'spam', 'junk email'];
+    const primaryFolderNames = ['inbox', 'starred', 'sent', 'sent items', 'draft', 'drafts', 'archive', 'trash', 'deleted items', 'spam', 'junk', 'junk email'];
 
     // Helper to get normalized folder name for comparison
     const getNormalizedName = (folder) => {
@@ -54,8 +53,9 @@ renderFolders(folders) {
         if (name === 'starred' || id === 'starred') return 1;
         if (name === 'sent' || name === 'sent items' || id === 'sent') return 2;
         if (name === 'draft' || name === 'drafts' || id === 'draft') return 3;
-        if (name === 'trash' || name === 'deleted items' || id === 'trash') return 4;
-        if (name === 'spam' || name === 'junk email' || id === 'spam') return 5;
+        if (name === 'archive' || id === 'archive') return 4;
+        if (name === 'trash' || name === 'deleted items' || id === 'trash') return 5;
+        if (name === 'spam' || name === 'junk' || name === 'junk email' || id === 'spam' || id === 'junk') return 6;
         return 99;
     };
 
@@ -90,10 +90,17 @@ renderFolders(folders) {
     // Sort other folders alphabetically
     otherFolders.sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
 
+    return [...primaryFolders, ...otherFolders];
+},
+
+renderFolders(folders) {
+    const folderList = document.getElementById('folderList') || document.querySelector('.folder-group');
+    if (!folderList) return;
+
+    const visibleFolders = this.getVisibleFolders(folders);
     folderList.innerHTML = '';
 
-    // Render primary folders
-    primaryFolders.forEach(folder => {
+    visibleFolders.forEach(folder => {
         const folderName = (folder.name || '').toLowerCase();
         const folderId = (folder.id || '').toLowerCase();
         // Check if this folder is the current one, or if it's inbox and no folder is selected yet
@@ -102,55 +109,6 @@ renderFolders(folders) {
         const item = this.createFolderElement(folder, isActive);
         folderList.appendChild(item);
     });
-
-    // Add "More" dropdown if there are other folders
-    if (otherFolders.length > 0) {
-        const moreContainer = this.createMoreDropdown(otherFolders);
-        folderList.appendChild(moreContainer);
-    }
-},
-
-createMoreDropdown(folders) {
-    const container = document.createElement('div');
-    container.className = 'folder-more-container';
-
-    const trigger = document.createElement('div');
-    trigger.className = 'folder-item folder-more-trigger';
-    trigger.innerHTML = `
-        <span class="folder-icon">📂</span>
-        <span>More</span>
-        <span class="folder-count">${folders.length}</span>
-        <svg class="folder-more-arrow" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path d="m6 9 6 6 6-6"/>
-        </svg>
-    `;
-
-    const dropdown = document.createElement('div');
-    dropdown.className = 'folder-more-dropdown hidden';
-
-    folders.forEach(folder => {
-        const item = this.createFolderElement(folder, false);
-        item.classList.add('folder-dropdown-item');
-        dropdown.appendChild(item);
-    });
-
-    trigger.addEventListener('click', (e) => {
-        e.stopPropagation();
-        dropdown.classList.toggle('hidden');
-        trigger.classList.toggle('expanded');
-    });
-
-    // Close dropdown when clicking outside
-    document.addEventListener('click', (e) => {
-        if (!container.contains(e.target)) {
-            dropdown.classList.add('hidden');
-            trigger.classList.remove('expanded');
-        }
-    });
-
-    container.appendChild(trigger);
-    container.appendChild(dropdown);
-    return container;
 },
 
 createFolderElement(folder, isActive = false) {
@@ -164,6 +122,7 @@ createFolderElement(folder, isActive = false) {
         'trash': '🗑️',
         'deleted items': '🗑️',
         'spam': '⚠️',
+        'junk': '⚠️',
         'junk email': '⚠️',
         'starred': '⭐',
         'snoozed': '🕐',
@@ -206,3 +165,7 @@ escapeHtml(str) {
     return div.innerHTML;
 },
 });
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = EmailFoldersManager;
+}

--- a/internal/air/static/js/email-folders.node.test.js
+++ b/internal/air/static/js/email-folders.node.test.js
@@ -1,0 +1,129 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const EmailFolders = require('./email-folders.js');
+
+function escapeHtml(value) {
+    return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+function createElement(tagName = 'div') {
+    const element = {
+        tagName,
+        children: [],
+        attributes: {},
+        className: '',
+        _innerHTML: '',
+        _textContent: '',
+        appendChild(child) {
+            this.children.push(child);
+            return child;
+        },
+        setAttribute(name, value) {
+            this.attributes[name] = String(value);
+        },
+        getAttribute(name) {
+            return this.attributes[name] || null;
+        },
+        removeAttribute(name) {
+            delete this.attributes[name];
+        },
+    };
+
+    Object.defineProperty(element, 'innerHTML', {
+        get() {
+            return this._innerHTML;
+        },
+        set(value) {
+            this._innerHTML = String(value);
+            if (value === '') {
+                this.children = [];
+            }
+        },
+    });
+
+    Object.defineProperty(element, 'textContent', {
+        get() {
+            return this._textContent;
+        },
+        set(value) {
+            this._textContent = String(value);
+            this._innerHTML = escapeHtml(value);
+        },
+    });
+
+    return element;
+}
+
+function createDocument(folderList) {
+    return {
+        getElementById(id) {
+            return id === 'folderList' ? folderList : null;
+        },
+        querySelector(selector) {
+            return selector === '.folder-group' ? folderList : null;
+        },
+        createElement() {
+            return createElement();
+        },
+    };
+}
+
+test.afterEach(() => {
+    delete global.document;
+    EmailFolders.currentFolder = 'INBOX';
+});
+
+test('getVisibleFolders keeps archive and junk visible while filtering provider pseudo-folders', () => {
+    const folders = [
+        { id: 'CATEGORY_SOCIAL', name: 'Social' },
+        { id: 'UNREAD', name: 'Unread' },
+        { id: 'scheduled', name: 'Scheduled' },
+        { id: 'outbox', name: 'Outbox' },
+        { id: 'projects', name: 'Projects' },
+        { id: 'archive', name: 'Archive' },
+        { id: 'junk', name: 'Junk' },
+        { id: 'trash', name: 'Trash' },
+        { id: 'drafts', name: 'Drafts' },
+        { id: 'sent', name: 'Sent' },
+        { id: 'starred', name: 'Starred' },
+        { id: 'inbox', name: 'Inbox' },
+    ];
+
+    const visibleNames = EmailFolders.getVisibleFolders(folders).map((folder) => folder.name);
+
+    assert.deepEqual(visibleNames, [
+        'Inbox',
+        'Starred',
+        'Sent',
+        'Drafts',
+        'Archive',
+        'Trash',
+        'Junk',
+        'Projects',
+    ]);
+});
+
+test('renderFolders renders all visible folders inline without a More entry', () => {
+    const folderList = createElement('div');
+    global.document = createDocument(folderList);
+    EmailFolders.currentFolder = 'archive';
+
+    EmailFolders.renderFolders([
+        { id: 'inbox', name: 'Inbox', unread_count: 3 },
+        { id: 'archive', name: 'Archive', total_count: 10 },
+        { id: 'projects', name: 'Projects', total_count: 4 },
+        { id: 'scheduled', name: 'Scheduled', total_count: 1 },
+    ]);
+
+    const renderedNames = folderList.children.map((child) => child.getAttribute('data-folder-name'));
+
+    assert.deepEqual(renderedNames, ['Inbox', 'Archive', 'Projects']);
+    assert.equal(renderedNames.includes('More'), false);
+    assert.equal(folderList.children[1].className.includes('active'), true);
+});

--- a/internal/air/static/js/smart-compose.js
+++ b/internal/air/static/js/smart-compose.js
@@ -20,6 +20,8 @@ const SmartCompose = {
         lastText: '',
         debounceTimer: null,
         textarea: null,
+        abortController: null,
+        requestId: 0,
     },
 
     /**
@@ -67,6 +69,9 @@ const SmartCompose = {
      */
     handleInput() {
         clearTimeout(this.state.debounceTimer);
+        this.state.debounceTimer = null;
+        this.cancelPendingRequest();
+        this.hideSuggestion();
 
         const text = this.state.textarea.value;
 
@@ -92,6 +97,11 @@ const SmartCompose = {
         // Don't fetch if text unchanged
         if (text === this.state.lastText) return;
         this.state.lastText = text;
+        this.cancelPendingRequest();
+
+        const controller = new AbortController();
+        const requestId = ++this.state.requestId;
+        this.state.abortController = controller;
 
         try {
             const response = await fetch('/api/ai/complete', {
@@ -101,16 +111,33 @@ const SmartCompose = {
                     text: text,
                     maxLength: this.config.maxSuggestionLength,
                 }),
+                signal: controller.signal,
             });
 
-            if (response.ok) {
-                const data = await response.json();
-                if (data.suggestion) {
-                    this.showSuggestion(data.suggestion);
-                }
+            if (!response.ok) {
+                this.hideSuggestion();
+                return;
+            }
+
+            const data = await response.json();
+            if (requestId !== this.state.requestId || text !== this.state.textarea.value) {
+                return;
+            }
+
+            if (data.suggestion) {
+                this.showSuggestion(data.suggestion);
+            } else {
+                this.hideSuggestion();
             }
         } catch (error) {
+            if (error && error.name === 'AbortError') {
+                return;
+            }
             console.error('Smart compose error:', error);
+        } finally {
+            if (this.state.abortController === controller) {
+                this.state.abortController = null;
+            }
         }
     },
 
@@ -166,10 +193,10 @@ const SmartCompose = {
         const { textarea } = this.state;
         textarea.value += this.state.currentSuggestion;
 
+        this.clearSuggestion();
+
         // Trigger input event for other listeners
         textarea.dispatchEvent(new Event('input', { bubbles: true }));
-
-        this.clearSuggestion();
 
         // Track acceptance for learning
         this.trackAcceptance();
@@ -179,12 +206,30 @@ const SmartCompose = {
      * Clear suggestion
      */
     clearSuggestion() {
+        this.cancelPendingRequest();
+        this.state.lastText = '';
+        this.hideSuggestion();
+    },
+
+    hideSuggestion() {
         this.state.currentSuggestion = '';
         this.state.isActive = false;
 
         if (this.overlay) {
             this.overlay.classList.remove('visible');
         }
+    },
+
+    cancelPendingRequest() {
+        if (this.state.debounceTimer) {
+            clearTimeout(this.state.debounceTimer);
+            this.state.debounceTimer = null;
+        }
+        if (this.state.abortController) {
+            this.state.abortController.abort();
+            this.state.abortController = null;
+        }
+        this.state.requestId += 1;
     },
 
     /**
@@ -220,4 +265,8 @@ const SmartCompose = {
 // Export for use
 if (typeof window !== 'undefined') {
     window.SmartCompose = SmartCompose;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = SmartCompose;
 }

--- a/internal/air/static/js/smart-compose.node.test.js
+++ b/internal/air/static/js/smart-compose.node.test.js
@@ -1,0 +1,185 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const SmartCompose = require('./smart-compose.js');
+
+function resetSmartCompose() {
+    SmartCompose.config.enabled = true;
+    SmartCompose.state.isActive = false;
+    SmartCompose.state.currentSuggestion = '';
+    SmartCompose.state.lastText = '';
+    SmartCompose.state.debounceTimer = null;
+    SmartCompose.state.textarea = {
+        value: '',
+        dispatchEvent() {},
+    };
+    SmartCompose.state.abortController = null;
+    SmartCompose.state.requestId = 0;
+    SmartCompose.overlay = {
+        classList: {
+            add() {},
+            remove() {},
+        },
+    };
+    SmartCompose.ghostEl = { textContent: '' };
+    SmartCompose.suggestionEl = { textContent: '' };
+}
+
+test.beforeEach(() => {
+    resetSmartCompose();
+});
+
+test.afterEach(() => {
+    delete global.fetch;
+});
+
+test('fetchSuggestion aborts the previous request and keeps the latest suggestion', async () => {
+    let firstRequestAborted = false;
+    let callCount = 0;
+
+    global.fetch = (url, init) => {
+        callCount += 1;
+        if (callCount === 1) {
+            return new Promise((resolve, reject) => {
+                init.signal.addEventListener('abort', () => {
+                    firstRequestAborted = true;
+                    const err = new Error('aborted');
+                    err.name = 'AbortError';
+                    reject(err);
+                });
+            });
+        }
+
+        return Promise.resolve({
+            ok: true,
+            json: async () => ({ suggestion: ' latest suggestion' }),
+        });
+    };
+
+    SmartCompose.state.textarea.value = 'drafting a long enough message';
+    const first = SmartCompose.fetchSuggestion('drafting a long enough message');
+
+    SmartCompose.state.textarea.value = 'drafting a longer replacement message';
+    const second = SmartCompose.fetchSuggestion('drafting a longer replacement message');
+
+    await Promise.all([first, second]);
+
+    assert.equal(firstRequestAborted, true);
+    assert.equal(SmartCompose.state.currentSuggestion, ' latest suggestion');
+    assert.equal(SmartCompose.suggestionEl.textContent, ' latest suggestion');
+});
+
+test('fetchSuggestion ignores a response for stale textarea content', async () => {
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => ({ suggestion: ' stale suggestion' }),
+    });
+
+    SmartCompose.state.textarea.value = 'drafting a long enough message';
+    const request = SmartCompose.fetchSuggestion('drafting a long enough message');
+    SmartCompose.state.textarea.value = 'edited before response returned';
+
+    await request;
+
+    assert.equal(SmartCompose.state.currentSuggestion, '');
+    assert.equal(SmartCompose.suggestionEl.textContent, '');
+});
+
+test('clearSuggestion invalidates a late response from an already-cleared request', async () => {
+    let resolveFetch;
+
+    global.fetch = () => new Promise((resolve) => {
+        resolveFetch = resolve;
+    });
+
+    SmartCompose.state.textarea.value = 'drafting a long enough message';
+    const request = SmartCompose.fetchSuggestion('drafting a long enough message');
+
+    SmartCompose.clearSuggestion();
+
+    resolveFetch({
+        ok: true,
+        json: async () => ({ suggestion: ' should stay hidden' }),
+    });
+
+    await request;
+
+    assert.equal(SmartCompose.state.currentSuggestion, '');
+    assert.equal(SmartCompose.suggestionEl.textContent, '');
+});
+
+test('clearSuggestion cancels a queued debounce before fetch starts', () => {
+    const originalSetTimeout = global.setTimeout;
+    const originalClearTimeout = global.clearTimeout;
+
+    let scheduled = null;
+    let clearedToken = null;
+    let fetchCalled = false;
+
+    global.setTimeout = (fn) => {
+        scheduled = fn;
+        return 42;
+    };
+    global.clearTimeout = (token) => {
+        clearedToken = token;
+        scheduled = null;
+    };
+    global.fetch = async () => {
+        fetchCalled = true;
+        return {
+            ok: true,
+            json: async () => ({ suggestion: ' should not run' }),
+        };
+    };
+
+    try {
+        SmartCompose.state.textarea.value = 'drafting a long enough message';
+        SmartCompose.handleInput();
+        SmartCompose.clearSuggestion();
+
+        assert.equal(clearedToken, 42);
+        assert.equal(scheduled, null);
+        assert.equal(fetchCalled, false);
+    } finally {
+        global.setTimeout = originalSetTimeout;
+        global.clearTimeout = originalClearTimeout;
+    }
+});
+
+test('handleInput aborts an in-flight request immediately while typing', async () => {
+    const originalSetTimeout = global.setTimeout;
+    const originalClearTimeout = global.clearTimeout;
+
+    let aborted = false;
+    let scheduled = null;
+
+    global.setTimeout = (fn) => {
+        scheduled = fn;
+        return 99;
+    };
+    global.clearTimeout = () => {};
+    global.fetch = (url, init) => new Promise((resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+            aborted = true;
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+        });
+    });
+
+    try {
+        SmartCompose.state.textarea.value = 'drafting a long enough message';
+        const request = SmartCompose.fetchSuggestion('drafting a long enough message');
+
+        SmartCompose.state.textarea.value = 'drafting a slightly longer message';
+        SmartCompose.handleInput();
+
+        await request;
+
+        assert.equal(aborted, true);
+        assert.equal(typeof scheduled, 'function');
+    } finally {
+        global.setTimeout = originalSetTimeout;
+        global.clearTimeout = originalClearTimeout;
+    }
+});

--- a/internal/app/auth/config.go
+++ b/internal/app/auth/config.go
@@ -1,8 +1,17 @@
 package auth
 
 import (
+	"encoding/json"
+	"errors"
+	"strings"
+
 	"github.com/nylas/cli/internal/domain"
 	"github.com/nylas/cli/internal/ports"
+)
+
+const (
+	storedGrantsKey       = "grants"
+	storedDefaultGrantKey = "default_grant"
 )
 
 // ConfigService handles configuration operations.
@@ -20,29 +29,70 @@ func NewConfigService(config ports.ConfigStore, secrets ports.SecretStore) *Conf
 }
 
 // SetupConfig saves the initial configuration.
-func (s *ConfigService) SetupConfig(region, clientID, clientSecret, apiKey, orgID string) error {
+func (s *ConfigService) SetupConfig(region, clientID, clientSecret, apiKey, orgID string) (err error) {
+	previousClientID, _ := s.secrets.Get(ports.KeyClientID)
+	previousAPIKey, _ := s.secrets.Get(ports.KeyAPIKey)
+	credentialsChanged := haveCredentialsChanged(previousClientID, clientID, previousAPIKey, apiKey)
+
+	secretSnapshots := []secretSnapshot{
+		newSecretSnapshot(s.secrets, ports.KeyClientID),
+		newSecretSnapshot(s.secrets, ports.KeyClientSecret),
+		newSecretSnapshot(s.secrets, ports.KeyAPIKey),
+		newSecretSnapshot(s.secrets, ports.KeyOrgID),
+		newSecretSnapshot(s.secrets, storedGrantsKey),
+		newSecretSnapshot(s.secrets, storedDefaultGrantKey),
+	}
+
+	// Preserve existing non-auth settings when refreshing credentials.
+	cfg, err := s.config.Load()
+	if err != nil || cfg == nil {
+		cfg = domain.DefaultConfig()
+	}
+	previousCfg := cloneConfig(cfg)
+
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		if rollbackErr := rollbackSetupState(s.config, s.secrets, previousCfg, secretSnapshots); rollbackErr != nil {
+			err = errors.Join(err, rollbackErr)
+		}
+	}()
+
 	// Save credentials to secret store
-	if err := s.secrets.Set(ports.KeyClientID, clientID); err != nil {
+	if err = s.secrets.Set(ports.KeyClientID, clientID); err != nil {
 		return err
 	}
 	if clientSecret != "" {
-		if err := s.secrets.Set(ports.KeyClientSecret, clientSecret); err != nil {
+		if err = s.secrets.Set(ports.KeyClientSecret, clientSecret); err != nil {
 			return err
 		}
 	}
-	if err := s.secrets.Set(ports.KeyAPIKey, apiKey); err != nil {
+	if err = s.secrets.Set(ports.KeyAPIKey, apiKey); err != nil {
 		return err
 	}
 	if orgID != "" {
-		if err := s.secrets.Set(ports.KeyOrgID, orgID); err != nil {
+		if err = s.secrets.Set(ports.KeyOrgID, orgID); err != nil {
 			return err
 		}
 	}
 
-	// Save config file (without credentials)
-	cfg := domain.DefaultConfig()
-	cfg.Region = region
-	return s.config.Save(cfg)
+	if credentialsChanged {
+		cfg.DefaultGrant = ""
+		cfg.Grants = nil
+		if err = clearStoredGrantState(s.secrets); err != nil {
+			return err
+		}
+	}
+	if region != "" {
+		cfg.Region = region
+	}
+	if err = s.config.Save(cfg); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // IsConfigured checks if the application is configured.
@@ -129,6 +179,7 @@ func (s *ConfigService) ResetConfig() error {
 	_ = s.secrets.Delete(ports.KeyClientSecret)
 	_ = s.secrets.Delete(ports.KeyAPIKey)
 	_ = s.secrets.Delete(ports.KeyOrgID)
+	_ = clearStoredGrantState(s.secrets)
 
 	// Reset config to defaults
 	return s.config.Save(domain.DefaultConfig())
@@ -171,4 +222,82 @@ func (s *ConfigService) EnsureConfig() (*domain.Config, bool, error) {
 		return nil, false, err
 	}
 	return cfg, true, nil
+}
+
+func haveCredentialsChanged(previousClientID, clientID, previousAPIKey, apiKey string) bool {
+	return strings.TrimSpace(previousClientID) != strings.TrimSpace(clientID) ||
+		strings.TrimSpace(previousAPIKey) != strings.TrimSpace(apiKey)
+}
+
+func clearStoredGrantState(secrets ports.SecretStore) error {
+	if err := secrets.Delete(storedGrantsKey); err != nil {
+		return err
+	}
+	if err := secrets.Delete(storedDefaultGrantKey); err != nil {
+		return err
+	}
+	return nil
+}
+
+type secretSnapshot struct {
+	key     string
+	value   string
+	present bool
+}
+
+func newSecretSnapshot(secrets ports.SecretStore, key string) secretSnapshot {
+	value, err := secrets.Get(key)
+	return secretSnapshot{
+		key:     key,
+		value:   value,
+		present: err == nil,
+	}
+}
+
+func restoreSecretSnapshots(secrets ports.SecretStore, snapshots []secretSnapshot) error {
+	var restoreErr error
+	for _, snapshot := range snapshots {
+		if snapshot.present {
+			if err := secrets.Set(snapshot.key, snapshot.value); err != nil {
+				restoreErr = errors.Join(restoreErr, err)
+			}
+			continue
+		}
+		if err := secrets.Delete(snapshot.key); err != nil {
+			restoreErr = errors.Join(restoreErr, err)
+		}
+	}
+
+	return restoreErr
+}
+
+func rollbackSetupState(config ports.ConfigStore, secrets ports.SecretStore, previousCfg *domain.Config, snapshots []secretSnapshot) error {
+	rollbackErr := restoreSecretSnapshots(secrets, snapshots)
+	if previousCfg != nil {
+		if err := config.Save(previousCfg); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+		}
+	}
+
+	return rollbackErr
+}
+
+func cloneConfig(cfg *domain.Config) *domain.Config {
+	if cfg == nil {
+		return nil
+	}
+
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		cloned := *cfg
+		return &cloned
+	}
+
+	var cloned domain.Config
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		cloned := *cfg
+		return &cloned
+	}
+
+	return &cloned
 }

--- a/internal/app/auth/config_test.go
+++ b/internal/app/auth/config_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/nylas/cli/internal/domain"
 	"github.com/nylas/cli/internal/ports"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +29,18 @@ func (m *mockSecretStore) Get(key string) (string, error) {
 func (m *mockSecretStore) Delete(key string) error { delete(m.data, key); return nil }
 func (m *mockSecretStore) IsAvailable() bool       { return true }
 func (m *mockSecretStore) Name() string            { return "mock" }
+
+type failingSecretStore struct {
+	*mockSecretStore
+	failDeleteKey string
+}
+
+func (s *failingSecretStore) Delete(key string) error {
+	if key == s.failDeleteKey {
+		return errors.New("delete failed")
+	}
+	return s.mockSecretStore.Delete(key)
+}
 
 func TestConfigService_ResetConfig(t *testing.T) {
 	t.Run("clears only API credentials", func(t *testing.T) {
@@ -58,4 +72,252 @@ func TestConfigService_ResetConfig(t *testing.T) {
 		assert.Equal(t, "user-token", secrets.data[ports.KeyDashboardUserToken])
 		assert.Equal(t, "app-id", secrets.data[ports.KeyDashboardAppID])
 	})
+}
+
+func TestConfigService_SetupConfig_PreservesExistingSettings(t *testing.T) {
+	secrets := newMockSecretStore()
+	secrets.data[ports.KeyClientID] = "old-client"
+	secrets.data[ports.KeyAPIKey] = "old-api-key"
+	secrets.data[storedGrantsKey] = `[{"id":"grant-123","email":"user@example.com","provider":"google"}]`
+	secrets.data[storedDefaultGrantKey] = "grant-123"
+	configStore := newMockConfigStore()
+	configStore.config = &domain.Config{
+		Region:       "eu",
+		CallbackPort: 7777,
+		DefaultGrant: "grant-123",
+		Grants: []domain.GrantInfo{{
+			ID:       "grant-123",
+			Email:    "user@example.com",
+			Provider: domain.ProviderGoogle,
+		}},
+		TUITheme: "oled",
+		WorkingHours: &domain.WorkingHoursConfig{
+			Default: &domain.DaySchedule{
+				Enabled: true,
+				Start:   "08:00",
+				End:     "16:00",
+			},
+		},
+		AI: &domain.AIConfig{
+			DefaultProvider: "openai",
+		},
+		GPG: &domain.GPGConfig{
+			DefaultKey: "ABC123",
+			AutoSign:   true,
+		},
+	}
+
+	svc := NewConfigService(configStore, secrets)
+
+	err := svc.SetupConfig("us", "client-123", "", "nyl_abc", "org-789")
+	require.NoError(t, err)
+
+	assert.Equal(t, "client-123", secrets.data[ports.KeyClientID])
+	assert.Equal(t, "nyl_abc", secrets.data[ports.KeyAPIKey])
+	assert.Equal(t, "org-789", secrets.data[ports.KeyOrgID])
+
+	cfg, err := configStore.Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, "us", cfg.Region)
+	assert.Equal(t, 7777, cfg.CallbackPort)
+	assert.Empty(t, cfg.DefaultGrant)
+	assert.Empty(t, cfg.Grants)
+	assert.Equal(t, "oled", cfg.TUITheme)
+	require.NotNil(t, cfg.WorkingHours)
+	require.NotNil(t, cfg.WorkingHours.Default)
+	assert.Equal(t, "08:00", cfg.WorkingHours.Default.Start)
+	require.NotNil(t, cfg.AI)
+	assert.Equal(t, "openai", cfg.AI.DefaultProvider)
+	require.NotNil(t, cfg.GPG)
+	assert.Equal(t, "ABC123", cfg.GPG.DefaultKey)
+	assert.Empty(t, secrets.data[storedGrantsKey])
+	assert.Empty(t, secrets.data[storedDefaultGrantKey])
+}
+
+func TestConfigService_SetupConfig_PreservesGrantStateWhenCredentialsDoNotChange(t *testing.T) {
+	secrets := newMockSecretStore()
+	secrets.data[ports.KeyClientID] = "client-123"
+	secrets.data[ports.KeyAPIKey] = "nyl_abc"
+	secrets.data[storedGrantsKey] = `[{"id":"grant-123","email":"user@example.com","provider":"google"}]`
+	secrets.data[storedDefaultGrantKey] = "grant-123"
+
+	configStore := newMockConfigStore()
+	configStore.config = &domain.Config{
+		Region:       "eu",
+		CallbackPort: 7777,
+		DefaultGrant: "grant-123",
+		Grants: []domain.GrantInfo{{
+			ID:       "grant-123",
+			Email:    "user@example.com",
+			Provider: domain.ProviderGoogle,
+		}},
+		TUITheme: "oled",
+	}
+
+	svc := NewConfigService(configStore, secrets)
+
+	err := svc.SetupConfig("us", "client-123", "", "nyl_abc", "org-789")
+	require.NoError(t, err)
+
+	cfg, err := configStore.Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, "grant-123", cfg.DefaultGrant)
+	require.Len(t, cfg.Grants, 1)
+	assert.Equal(t, "grant-123", cfg.Grants[0].ID)
+	assert.Equal(t, "grant-123", secrets.data[storedDefaultGrantKey])
+	assert.NotEmpty(t, secrets.data[storedGrantsKey])
+}
+
+func TestConfigService_SetupConfig_RollsBackOnConfigSaveFailure(t *testing.T) {
+	secrets := newMockSecretStore()
+	secrets.data[ports.KeyClientID] = "old-client"
+	secrets.data[ports.KeyClientSecret] = "old-secret"
+	secrets.data[ports.KeyAPIKey] = "old-api-key"
+	secrets.data[ports.KeyOrgID] = "old-org"
+	secrets.data[storedGrantsKey] = `[{"id":"grant-123","email":"user@example.com","provider":"google"}]`
+	secrets.data[storedDefaultGrantKey] = "grant-123"
+
+	configStore := &failingSetupConfigStore{
+		config: &domain.Config{
+			Region:       "eu",
+			CallbackPort: 7777,
+			DefaultGrant: "grant-123",
+			Grants: []domain.GrantInfo{{
+				ID:       "grant-123",
+				Email:    "user@example.com",
+				Provider: domain.ProviderGoogle,
+			}},
+			TUITheme: "oled",
+		},
+		err: errors.New("disk full"),
+	}
+
+	svc := NewConfigService(configStore, secrets)
+
+	err := svc.SetupConfig("us", "client-123", "", "new-api-key", "org-789")
+	require.Error(t, err)
+
+	assert.Equal(t, "old-client", secrets.data[ports.KeyClientID])
+	assert.Equal(t, "old-secret", secrets.data[ports.KeyClientSecret])
+	assert.Equal(t, "old-api-key", secrets.data[ports.KeyAPIKey])
+	assert.Equal(t, "old-org", secrets.data[ports.KeyOrgID])
+	assert.Equal(t, `[{"id":"grant-123","email":"user@example.com","provider":"google"}]`, secrets.data[storedGrantsKey])
+	assert.Equal(t, "grant-123", secrets.data[storedDefaultGrantKey])
+
+	cfg, loadErr := configStore.Load()
+	require.NoError(t, loadErr)
+	assert.Equal(t, "eu", cfg.Region)
+	assert.Equal(t, "grant-123", cfg.DefaultGrant)
+	require.Len(t, cfg.Grants, 1)
+	assert.Equal(t, "grant-123", cfg.Grants[0].ID)
+	assert.Equal(t, "oled", cfg.TUITheme)
+}
+
+func TestConfigService_SetupConfig_ClearsGrantStateWhenPreviousAPIKeyIsMissing(t *testing.T) {
+	secrets := newMockSecretStore()
+	secrets.data[ports.KeyClientID] = "client-123"
+	secrets.data[storedGrantsKey] = `[{"id":"grant-123","email":"user@example.com","provider":"google"}]`
+	secrets.data[storedDefaultGrantKey] = "grant-123"
+
+	configStore := newMockConfigStore()
+	configStore.config = &domain.Config{
+		Region:       "eu",
+		CallbackPort: 7777,
+		DefaultGrant: "grant-123",
+		Grants: []domain.GrantInfo{{
+			ID:       "grant-123",
+			Email:    "user@example.com",
+			Provider: domain.ProviderGoogle,
+		}},
+		TUITheme: "oled",
+	}
+
+	svc := NewConfigService(configStore, secrets)
+
+	err := svc.SetupConfig("us", "client-123", "", "nyl_new", "org-789")
+	require.NoError(t, err)
+
+	cfg, loadErr := configStore.Load()
+	require.NoError(t, loadErr)
+
+	assert.Equal(t, "us", cfg.Region)
+	assert.Empty(t, cfg.DefaultGrant)
+	assert.Empty(t, cfg.Grants)
+	assert.Equal(t, "oled", cfg.TUITheme)
+	assert.Equal(t, "nyl_new", secrets.data[ports.KeyAPIKey])
+	assert.Empty(t, secrets.data[storedGrantsKey])
+	assert.Empty(t, secrets.data[storedDefaultGrantKey])
+}
+
+func TestConfigService_SetupConfig_RollsBackOnSecretStoreFailure(t *testing.T) {
+	baseSecrets := newMockSecretStore()
+	baseSecrets.data[ports.KeyClientID] = "old-client"
+	baseSecrets.data[ports.KeyAPIKey] = "old-api-key"
+	baseSecrets.data[ports.KeyOrgID] = "old-org"
+	baseSecrets.data[storedGrantsKey] = `[{"id":"grant-123","email":"user@example.com","provider":"google"}]`
+	baseSecrets.data[storedDefaultGrantKey] = "grant-123"
+
+	secrets := &failingSecretStore{
+		mockSecretStore: baseSecrets,
+		failDeleteKey:   storedDefaultGrantKey,
+	}
+
+	configStore := newMockConfigStore()
+	configStore.config = &domain.Config{
+		Region:       "eu",
+		CallbackPort: 7777,
+		DefaultGrant: "grant-123",
+		Grants: []domain.GrantInfo{{
+			ID:       "grant-123",
+			Email:    "user@example.com",
+			Provider: domain.ProviderGoogle,
+		}},
+		TUITheme: "oled",
+	}
+
+	svc := NewConfigService(configStore, secrets)
+
+	err := svc.SetupConfig("us", "client-123", "", "new-api-key", "org-789")
+	require.Error(t, err)
+
+	assert.Equal(t, "old-client", baseSecrets.data[ports.KeyClientID])
+	assert.Equal(t, "old-api-key", baseSecrets.data[ports.KeyAPIKey])
+	assert.Equal(t, "old-org", baseSecrets.data[ports.KeyOrgID])
+	assert.Equal(t, `[{"id":"grant-123","email":"user@example.com","provider":"google"}]`, baseSecrets.data[storedGrantsKey])
+	assert.Equal(t, "grant-123", baseSecrets.data[storedDefaultGrantKey])
+
+	cfg, loadErr := configStore.Load()
+	require.NoError(t, loadErr)
+	assert.Equal(t, "eu", cfg.Region)
+	assert.Equal(t, "grant-123", cfg.DefaultGrant)
+	require.Len(t, cfg.Grants, 1)
+	assert.Equal(t, "grant-123", cfg.Grants[0].ID)
+	assert.Equal(t, "oled", cfg.TUITheme)
+}
+
+type failingSetupConfigStore struct {
+	config *domain.Config
+	err    error
+}
+
+func (m *failingSetupConfigStore) Load() (*domain.Config, error) {
+	return cloneConfig(m.config), nil
+}
+
+func (m *failingSetupConfigStore) Save(cfg *domain.Config) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.config = cloneConfig(cfg)
+	return nil
+}
+
+func (m *failingSetupConfigStore) Path() string {
+	return "/tmp/test-config.yaml"
+}
+
+func (m *failingSetupConfigStore) Exists() bool {
+	return m.config != nil
 }

--- a/internal/app/auth/grants.go
+++ b/internal/app/auth/grants.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 
 	"github.com/nylas/cli/internal/domain"
 	"github.com/nylas/cli/internal/ports"
@@ -139,23 +140,52 @@ func (s *GrantService) SwitchGrantByEmail(email string) error {
 	return s.setDefaultGrant(info.ID)
 }
 
-// setDefaultGrant updates the default grant in both keyring and config file.
-func (s *GrantService) setDefaultGrant(grantID string) error {
-	// Update keyring
-	if err := s.grantStore.SetDefaultGrant(grantID); err != nil {
+// PersistDefaultGrant updates both the config file and grant store so all
+// callers observe the same default grant value.
+func PersistDefaultGrant(config ports.ConfigStore, grantStore ports.GrantStore, grantID string) error {
+	var (
+		cfgToSave    *domain.Config
+		rollbackCfg  *domain.Config
+		configLoaded bool
+	)
+
+	if config != nil {
+		cfg, err := config.Load()
+		if err == nil && cfg != nil {
+			configLoaded = true
+			rollbackCfg = cloneConfig(cfg)
+			cfgToSave = cloneConfig(cfg)
+		} else {
+			cfgToSave = domain.DefaultConfig()
+		}
+
+		cfgToSave.DefaultGrant = grantID
+		if err := config.Save(cfgToSave); err != nil {
+			return err
+		}
+	}
+
+	if err := grantStore.SetDefaultGrant(grantID); err != nil {
+		if config == nil {
+			return err
+		}
+
+		restoreCfg := rollbackCfg
+		if !configLoaded || restoreCfg == nil {
+			restoreCfg = domain.DefaultConfig()
+		}
+		if rollbackErr := config.Save(restoreCfg); rollbackErr != nil {
+			return errors.Join(err, rollbackErr)
+		}
 		return err
 	}
 
-	// Update config file
-	cfg, err := s.config.Load()
-	if err != nil {
-		// Non-fatal: keyring is the authoritative source
-		return nil
-	}
-	cfg.DefaultGrant = grantID
-	_ = s.config.Save(cfg) // Ignore save errors, keyring is authoritative
-
 	return nil
+}
+
+// setDefaultGrant updates the default grant in both keyring and config file.
+func (s *GrantService) setDefaultGrant(grantID string) error {
+	return PersistDefaultGrant(s.config, s.grantStore, grantID)
 }
 
 // ValidateGrant checks if a grant is valid.
@@ -186,12 +216,12 @@ func (s *GrantService) AddGrant(grantID, email string, provider domain.Provider,
 
 	// Set as default if requested or if this is the first grant
 	if setDefault {
-		return s.grantStore.SetDefaultGrant(grantID)
+		return s.setDefaultGrant(grantID)
 	}
 
 	// Auto-set as default if no default exists
 	if _, err := s.grantStore.GetDefaultGrant(); err == domain.ErrNoDefaultGrant {
-		return s.grantStore.SetDefaultGrant(grantID)
+		return s.setDefaultGrant(grantID)
 	}
 
 	return nil

--- a/internal/app/auth/grants_test.go
+++ b/internal/app/auth/grants_test.go
@@ -56,7 +56,7 @@ func TestGrantService_SwitchGrant(t *testing.T) {
 		assert.Equal(t, "grant-1", defaultID)
 	})
 
-	t.Run("succeeds even if config save fails", func(t *testing.T) {
+	t.Run("returns error if config save fails and leaves keyring unchanged", func(t *testing.T) {
 		grantStore := newMockGrantStore()
 		configStore := &failingSaveConfigStore{config: &domain.Config{DefaultGrant: "grant-1"}}
 		client := nylas.NewMockClient()
@@ -67,15 +67,13 @@ func TestGrantService_SwitchGrant(t *testing.T) {
 
 		svc := NewGrantService(client, grantStore, configStore)
 
-		// Should succeed - keyring is authoritative, config save failure is non-fatal
 		err := svc.SwitchGrant("grant-2")
 
-		require.NoError(t, err)
+		require.Error(t, err)
 
-		// Verify keyring was updated
 		defaultID, err := grantStore.GetDefaultGrant()
 		require.NoError(t, err)
-		assert.Equal(t, "grant-2", defaultID)
+		assert.Equal(t, "grant-1", defaultID)
 	})
 }
 
@@ -148,6 +146,7 @@ func TestGrantService_AddGrant(t *testing.T) {
 		defaultID, err := grantStore.GetDefaultGrant()
 		require.NoError(t, err)
 		assert.Equal(t, "grant-1", defaultID)
+		assert.Equal(t, "grant-1", configStore.config.DefaultGrant)
 	})
 
 	t.Run("auto-sets first grant as default", func(t *testing.T) {
@@ -166,6 +165,7 @@ func TestGrantService_AddGrant(t *testing.T) {
 		defaultID, err := grantStore.GetDefaultGrant()
 		require.NoError(t, err)
 		assert.Equal(t, "grant-1", defaultID)
+		assert.Equal(t, "grant-1", configStore.config.DefaultGrant)
 	})
 
 	t.Run("does not override existing default", func(t *testing.T) {

--- a/internal/cli/auth/config.go
+++ b/internal/cli/auth/config.go
@@ -103,14 +103,14 @@ The CLI only requires your API Key - Client ID is auto-detected.`,
 				} else if len(apps) == 1 {
 					// Single app - auto-select
 					app := apps[0]
-					clientID = getAppClientID(app)
+					clientID = setup.AppClientID(app)
 					orgID = app.OrganizationID
-					_, _ = common.Green.Printf("  ✓ Found application: %s\n", getAppDisplayName(app))
+					_, _ = common.Green.Printf("  ✓ Found application: %s\n", setup.AppDisplayName(app))
 				} else {
 					// Multiple apps - let user choose
 					fmt.Printf("  Found %d applications:\n\n", len(apps))
 					for i, app := range apps {
-						fmt.Printf("  [%d] %s\n", i+1, getAppDisplayName(app))
+						fmt.Printf("  [%d] %s\n", i+1, setup.AppDisplayName(app))
 					}
 					fmt.Println()
 					fmt.Print("Select application (1-", len(apps), "): ")
@@ -123,9 +123,9 @@ The CLI only requires your API Key - Client ID is auto-detected.`,
 					}
 
 					app := apps[selected-1]
-					clientID = getAppClientID(app)
+					clientID = setup.AppClientID(app)
 					orgID = app.OrganizationID
-					_, _ = common.Green.Printf("  ✓ Selected: %s\n", getAppDisplayName(app))
+					_, _ = common.Green.Printf("  ✓ Selected: %s\n", setup.AppDisplayName(app))
 				}
 			}
 
@@ -146,63 +146,25 @@ The CLI only requires your API Key - Client ID is auto-detected.`,
 
 			// Load config to get callback port
 			cfg, err := configStore.Load()
-			if err != nil {
+			if err != nil || cfg == nil {
 				_, _ = common.Yellow.Printf("  Warning: Could not load config: %v\n", err)
+				cfg = domain.DefaultConfig()
 			}
 
 			// Ensure callback URI exists in the application
-			if cfg != nil {
-				// Get callback port from config (defaults to 9007)
-				callbackPort := cfg.CallbackPort
-				if callbackPort == 0 {
-					callbackPort = 9007
-				}
-
-				requiredCallbackURI := fmt.Sprintf("http://localhost:%d/callback", callbackPort)
-
-				client := nylasadapter.NewHTTPClient()
-				client.SetRegion(region)
-				client.SetCredentials(clientID, "", apiKey)
-
-				// List existing callback URIs via dedicated endpoint
-				ctx, cancel := common.CreateContext()
-				existingURIs, err := client.ListCallbackURIs(ctx)
-				cancel()
-
-				hasCallbackURI := false
-				if err == nil {
-					for _, cb := range existingURIs {
-						if cb.URL == requiredCallbackURI {
-							hasCallbackURI = true
-							break
-						}
-					}
-				}
-
+			callbackResult, callbackErr := setup.EnsureOAuthCallbackURI(apiKey, clientID, region, cfg.CallbackPort)
+			fmt.Println()
+			if callbackErr != nil {
+				_, _ = common.Yellow.Printf("  Could not add callback URI automatically: %v\n", callbackErr)
+				fmt.Printf("  Please add this callback URI manually in the Nylas dashboard:\n")
+				fmt.Printf("    %s\n", callbackResult.RequiredURI)
 				fmt.Println()
-				if !hasCallbackURI {
-					fmt.Println("Setting up callback URI for OAuth authentication...")
-
-					ctx, cancel := common.CreateContext()
-					_, err := client.CreateCallbackURI(ctx, &domain.CreateCallbackURIRequest{
-						URL:      requiredCallbackURI,
-						Platform: "web",
-					})
-					cancel()
-
-					if err != nil {
-						_, _ = common.Yellow.Printf("  Could not add callback URI automatically: %v\n", err)
-						fmt.Printf("  Please add this callback URI manually in the Nylas dashboard:\n")
-						fmt.Printf("    %s\n", requiredCallbackURI)
-						fmt.Println()
-						fmt.Printf("  Dashboard: https://dashboard.nylas.com/applications\n")
-						fmt.Printf("  Navigate to: Your App → Settings → Callback URIs → Add URI\n")
-					} else {
-						_, _ = common.Green.Printf("  ✓ Added callback URI: %s\n", requiredCallbackURI)
-					}
-				} else {
-					_, _ = common.Green.Println("✓ Callback URI already configured")
-				}
+				fmt.Printf("  Dashboard: https://dashboard.nylas.com/applications\n")
+				fmt.Printf("  Navigate to: Your App → Settings → Callback URIs → Add URI\n")
+			} else if callbackResult.Created {
+				_, _ = common.Green.Printf("  ✓ Added callback URI: %s\n", callbackResult.RequiredURI)
+			} else if callbackResult.AlreadyExists {
+				_, _ = common.Green.Println("✓ Callback URI already configured")
 			}
 
 			// Auto-detect existing grants from Nylas API
@@ -276,37 +238,6 @@ The CLI only requires your API Key - Client ID is auto-detected.`,
 	cmd.Flags().BoolVar(&reset, "reset", false, "Reset all configuration")
 
 	return cmd
-}
-
-// getAppClientID returns the client ID for an application.
-// It checks both ID and ApplicationID fields since the API may use either.
-func getAppClientID(app domain.Application) string {
-	if app.ApplicationID != "" {
-		return app.ApplicationID
-	}
-	return app.ID
-}
-
-// getAppDisplayName returns a human-readable display name for an application.
-func getAppDisplayName(app domain.Application) string {
-	clientID := getAppClientID(app)
-	env := app.Environment
-	if env == "" {
-		env = "production"
-	}
-
-	region := app.Region
-	if region == "" {
-		region = "us"
-	}
-
-	// Truncate client ID for display if too long
-	displayID := clientID
-	if len(displayID) > 20 {
-		displayID = displayID[:17] + "..."
-	}
-
-	return fmt.Sprintf("%s (%s, %s)", displayID, env, region)
 }
 
 // sanitizeAPIKey removes all characters that are invalid in HTTP headers.

--- a/internal/cli/dashboard/exports.go
+++ b/internal/cli/dashboard/exports.go
@@ -26,9 +26,10 @@ func AcceptPrivacyPolicy() error {
 	return acceptPrivacyPolicy(false)
 }
 
-// ActivateAPIKey stores an API key in the keyring and configures the CLI (exported for setup wizard).
-func ActivateAPIKey(apiKey, clientID, region string) error {
-	return activateAPIKey(apiKey, clientID, region)
+// ActivateAPIKey stores an API key in the keyring and configures the CLI
+// (exported for setup wizard).
+func ActivateAPIKey(apiKey, clientID, region, orgID string) error {
+	return activateAPIKey(apiKey, clientID, region, orgID)
 }
 
 // GetActiveOrgID retrieves the active organization ID (exported for setup wizard).

--- a/internal/cli/dashboard/keys.go
+++ b/internal/cli/dashboard/keys.go
@@ -221,7 +221,7 @@ func handleAPIKeyDelivery(apiKey, appID, region, delivery string) error {
 
 	switch choice {
 	case "activate":
-		if err := activateAPIKey(apiKey, appID, region); err != nil {
+		if err := activateAPIKey(apiKey, appID, region, ""); err != nil {
 			_, _ = common.Yellow.Printf("  Could not activate: %v\n", err)
 			return nil
 		}
@@ -356,7 +356,11 @@ func tempSecretPattern(filename string) string {
 }
 
 // activateAPIKey stores the API key and configures the CLI to use it.
-func activateAPIKey(apiKey, clientID, region string) error {
+func activateAPIKey(apiKey, clientID, region, orgID string) error {
+	if strings.TrimSpace(clientID) == "" {
+		return fmt.Errorf("client ID is required to activate an API key")
+	}
+
 	configStore := config.NewDefaultFileStore()
 	secretStore, err := keyring.NewSecretStore(config.DefaultConfigDir())
 	if err != nil {
@@ -364,7 +368,7 @@ func activateAPIKey(apiKey, clientID, region string) error {
 	}
 
 	configSvc := authapp.NewConfigService(configStore, secretStore)
-	return configSvc.SetupConfig(region, clientID, "", apiKey, "")
+	return configSvc.SetupConfig(region, clientID, "", apiKey, orgID)
 }
 
 // toAPIKeyRows converts API keys to flat display rows.

--- a/internal/cli/setup/api_key_setup_test.go
+++ b/internal/cli/setup/api_key_setup_test.go
@@ -1,0 +1,145 @@
+package setup
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nylas/cli/internal/domain"
+)
+
+type testAPIKeySetupClient struct {
+	apps              []domain.Application
+	listAppsErr       error
+	callbackURIs      []domain.CallbackURI
+	listCallbackErr   error
+	createCallbackErr error
+	createdRequests   []*domain.CreateCallbackURIRequest
+}
+
+func (m *testAPIKeySetupClient) ListApplications(context.Context) ([]domain.Application, error) {
+	return m.apps, m.listAppsErr
+}
+
+func (m *testAPIKeySetupClient) ListCallbackURIs(context.Context) ([]domain.CallbackURI, error) {
+	return m.callbackURIs, m.listCallbackErr
+}
+
+func (m *testAPIKeySetupClient) CreateCallbackURI(_ context.Context, req *domain.CreateCallbackURIRequest) (*domain.CallbackURI, error) {
+	m.createdRequests = append(m.createdRequests, req)
+	if m.createCallbackErr != nil {
+		return nil, m.createCallbackErr
+	}
+	return &domain.CallbackURI{ID: "cb-new", URL: req.URL, Platform: req.Platform}, nil
+}
+
+func TestResolveAPIKeyApplication_AutoSelectsSingleApp(t *testing.T) {
+	t.Parallel()
+
+	client := &testAPIKeySetupClient{
+		apps: []domain.Application{{
+			ID:             "app-1",
+			ApplicationID:  "client-123",
+			OrganizationID: "org-456",
+		}},
+	}
+
+	result, err := resolveAPIKeyApplication("nyl_test", "us", "", false, func(region, clientID, apiKey string) apiKeySetupClient {
+		return client
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.ClientID != "client-123" {
+		t.Fatalf("expected client ID %q, got %q", "client-123", result.ClientID)
+	}
+	if result.OrgID != "org-456" {
+		t.Fatalf("expected org ID %q, got %q", "org-456", result.OrgID)
+	}
+}
+
+func TestResolveAPIKeyApplication_RequiresClientIDWhenMultipleAppsExist(t *testing.T) {
+	t.Parallel()
+
+	client := &testAPIKeySetupClient{
+		apps: []domain.Application{
+			{ApplicationID: "client-1"},
+			{ApplicationID: "client-2"},
+		},
+	}
+
+	_, err := resolveAPIKeyApplication("nyl_test", "us", "", false, func(region, clientID, apiKey string) apiKeySetupClient {
+		return client
+	})
+	if err == nil {
+		t.Fatal("expected error when multiple applications exist without an explicit client ID")
+	}
+	if !strings.Contains(err.Error(), "--client-id") {
+		t.Fatalf("expected client-id guidance in error, got %v", err)
+	}
+}
+
+func TestResolveAPIKeyApplication_RejectsUnknownExplicitClientID(t *testing.T) {
+	t.Parallel()
+
+	client := &testAPIKeySetupClient{
+		apps: []domain.Application{
+			{ApplicationID: "client-1"},
+		},
+	}
+
+	_, err := resolveAPIKeyApplication("nyl_test", "us", "missing-client", false, func(region, clientID, apiKey string) apiKeySetupClient {
+		return client
+	})
+	if err == nil {
+		t.Fatal("expected error for an explicit client ID that does not belong to the API key")
+	}
+	if !strings.Contains(err.Error(), "missing-client") {
+		t.Fatalf("expected explicit client ID in error, got %v", err)
+	}
+}
+
+func TestEnsureOAuthCallbackURI_ReturnsAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	client := &testAPIKeySetupClient{
+		callbackURIs: []domain.CallbackURI{
+			{ID: "cb-1", URL: "http://localhost:9007/callback", Platform: "web"},
+		},
+	}
+
+	result, err := ensureOAuthCallbackURI("nyl_test", "client-123", "us", 9007, func(region, clientID, apiKey string) apiKeySetupClient {
+		return client
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !result.AlreadyExists {
+		t.Fatal("expected callback URI to be reported as already existing")
+	}
+	if len(client.createdRequests) != 0 {
+		t.Fatalf("expected no callback URI creation request, got %d", len(client.createdRequests))
+	}
+}
+
+func TestEnsureOAuthCallbackURI_CreatesMissingURI(t *testing.T) {
+	t.Parallel()
+
+	client := &testAPIKeySetupClient{}
+
+	result, err := ensureOAuthCallbackURI("nyl_test", "client-123", "us", 9007, func(region, clientID, apiKey string) apiKeySetupClient {
+		return client
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !result.Created {
+		t.Fatal("expected callback URI to be created")
+	}
+	if len(client.createdRequests) != 1 {
+		t.Fatalf("expected one create callback request, got %d", len(client.createdRequests))
+	}
+	if got := client.createdRequests[0].URL; got != "http://localhost:9007/callback" {
+		t.Fatalf("expected callback URI %q, got %q", "http://localhost:9007/callback", got)
+	}
+}

--- a/internal/cli/setup/application_setup.go
+++ b/internal/cli/setup/application_setup.go
@@ -1,0 +1,190 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	nylasadapter "github.com/nylas/cli/internal/adapters/nylas"
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/nylas/cli/internal/domain"
+)
+
+type apiKeySetupClient interface {
+	ListApplications(ctx context.Context) ([]domain.Application, error)
+	ListCallbackURIs(ctx context.Context) ([]domain.CallbackURI, error)
+	CreateCallbackURI(ctx context.Context, req *domain.CreateCallbackURIRequest) (*domain.CallbackURI, error)
+}
+
+// APIKeyApplication identifies the application that should be used with a
+// provided API key during setup flows.
+type APIKeyApplication struct {
+	ClientID string
+	OrgID    string
+}
+
+// CallbackURIProvisionResult reports whether the expected OAuth callback URI
+// already existed or was created during setup.
+type CallbackURIProvisionResult struct {
+	RequiredURI   string
+	AlreadyExists bool
+	Created       bool
+}
+
+func newAPIKeySetupClient(region, clientID, apiKey string) apiKeySetupClient {
+	client := nylasadapter.NewHTTPClient()
+	client.SetRegion(region)
+	client.SetCredentials(clientID, "", apiKey)
+	return client
+}
+
+// AppClientID returns the stable client/application ID for a Nylas application.
+func AppClientID(app domain.Application) string {
+	if app.ApplicationID != "" {
+		return app.ApplicationID
+	}
+	return app.ID
+}
+
+// AppDisplayName returns a human-readable display name for a Nylas application.
+func AppDisplayName(app domain.Application) string {
+	clientID := AppClientID(app)
+	env := app.Environment
+	if env == "" {
+		env = "production"
+	}
+
+	region := app.Region
+	if region == "" {
+		region = "us"
+	}
+
+	displayID := clientID
+	if len(displayID) > 20 {
+		displayID = displayID[:17] + "..."
+	}
+
+	return fmt.Sprintf("%s (%s, %s)", displayID, env, region)
+}
+
+// ResolveAPIKeyApplication selects the application that should back an API-key
+// based setup flow. In non-interactive mode, multiple applications require an
+// explicit client ID.
+func ResolveAPIKeyApplication(apiKey, region, explicitClientID string, interactive bool) (*APIKeyApplication, error) {
+	return resolveAPIKeyApplication(apiKey, region, explicitClientID, interactive, newAPIKeySetupClient)
+}
+
+func resolveAPIKeyApplication(
+	apiKey, region, explicitClientID string,
+	interactive bool,
+	clientFactory func(region, clientID, apiKey string) apiKeySetupClient,
+) (*APIKeyApplication, error) {
+	explicitClientID = strings.TrimSpace(explicitClientID)
+
+	client := clientFactory(region, "", apiKey)
+
+	ctx, cancel := common.CreateContext()
+	defer cancel()
+
+	apps, err := client.ListApplications(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not auto-detect application: %w", err)
+	}
+	if len(apps) == 0 {
+		return nil, fmt.Errorf("no applications found for this API key")
+	}
+
+	if explicitClientID != "" {
+		for _, app := range apps {
+			if AppClientID(app) == explicitClientID {
+				return &APIKeyApplication{
+					ClientID: explicitClientID,
+					OrgID:    app.OrganizationID,
+				}, nil
+			}
+		}
+		return nil, fmt.Errorf("client ID %q was not found for this API key", explicitClientID)
+	}
+
+	if len(apps) == 1 {
+		app := apps[0]
+		return &APIKeyApplication{
+			ClientID: AppClientID(app),
+			OrgID:    app.OrganizationID,
+		}, nil
+	}
+
+	if !interactive {
+		return nil, fmt.Errorf("multiple applications found for this API key; rerun with --client-id or use interactive setup")
+	}
+
+	options := make([]common.SelectOption[int], len(apps))
+	for i, app := range apps {
+		options[i] = common.SelectOption[int]{
+			Label: AppDisplayName(app),
+			Value: i,
+		}
+	}
+
+	selectedIndex, err := common.Select("Select application", options)
+	if err != nil {
+		return nil, err
+	}
+
+	selected := apps[selectedIndex]
+	return &APIKeyApplication{
+		ClientID: AppClientID(selected),
+		OrgID:    selected.OrganizationID,
+	}, nil
+}
+
+// EnsureOAuthCallbackURI provisions the expected localhost callback URI for the
+// selected application when it does not already exist.
+func EnsureOAuthCallbackURI(apiKey, clientID, region string, callbackPort int) (*CallbackURIProvisionResult, error) {
+	return ensureOAuthCallbackURI(apiKey, clientID, region, callbackPort, newAPIKeySetupClient)
+}
+
+func ensureOAuthCallbackURI(
+	apiKey, clientID, region string,
+	callbackPort int,
+	clientFactory func(region, clientID, apiKey string) apiKeySetupClient,
+) (*CallbackURIProvisionResult, error) {
+	if callbackPort == 0 {
+		callbackPort = 9007
+	}
+
+	result := &CallbackURIProvisionResult{
+		RequiredURI: fmt.Sprintf("http://localhost:%d/callback", callbackPort),
+	}
+	if strings.TrimSpace(clientID) == "" {
+		return result, fmt.Errorf("client ID is required to configure the OAuth callback URI")
+	}
+
+	client := clientFactory(region, clientID, apiKey)
+
+	ctx, cancel := common.CreateContext()
+	existingURIs, listErr := client.ListCallbackURIs(ctx)
+	cancel()
+
+	if listErr == nil {
+		for _, cb := range existingURIs {
+			if cb.URL == result.RequiredURI {
+				result.AlreadyExists = true
+				return result, nil
+			}
+		}
+	}
+
+	ctx, cancel = common.CreateContext()
+	_, createErr := client.CreateCallbackURI(ctx, &domain.CreateCallbackURIRequest{
+		URL:      result.RequiredURI,
+		Platform: "web",
+	})
+	cancel()
+	if createErr != nil {
+		return result, createErr
+	}
+
+	result.Created = true
+	return result, nil
+}

--- a/internal/cli/setup/setup.go
+++ b/internal/cli/setup/setup.go
@@ -27,6 +27,9 @@ Already have an API key? Skip the wizard:
   # Quick setup with existing API key
   nylas init --api-key nyl_abc123
 
+  # Quick setup for a specific application
+  nylas init --api-key nyl_abc123 --client-id app-123
+
   # Quick setup with region
   nylas init --api-key nyl_abc123 --region eu
 
@@ -38,6 +41,7 @@ Already have an API key? Skip the wizard:
 	}
 
 	cmd.Flags().StringVar(&opts.apiKey, "api-key", "", "Nylas API key (skips interactive setup)")
+	cmd.Flags().StringVar(&opts.clientID, "client-id", "", "Nylas Client ID to use with --api-key")
 	cmd.Flags().StringVarP(&opts.region, "region", "r", "us", "API region (us or eu)")
 	cmd.Flags().BoolVar(&opts.google, "google", false, "Use Google SSO")
 	cmd.Flags().BoolVar(&opts.microsoft, "microsoft", false, "Use Microsoft SSO")

--- a/internal/cli/setup/wizard.go
+++ b/internal/cli/setup/wizard.go
@@ -18,6 +18,7 @@ import (
 // wizardOpts holds the options parsed from CLI flags.
 type wizardOpts struct {
 	apiKey    string
+	clientID  string
 	region    string
 	google    bool
 	microsoft bool
@@ -36,6 +37,16 @@ const (
 const (
 	stepTotal = 4
 	divider   = "──────────────────────────────────────────"
+)
+
+var (
+	verifyAPIKeyFn             = verifyAPIKey
+	resolveAPIKeyApplicationFn = ResolveAPIKeyApplication
+	ensureSetupCallbackURIFn   = ensureSetupCallbackURI
+	activateAPIKeyFn           = dashboard.ActivateAPIKey
+	getSetupStatusFn           = GetSetupStatus
+	stepGrantSyncFn            = stepGrantSync
+	printCompleteFn            = printComplete
 )
 
 func runWizard(opts wizardOpts) error {
@@ -91,10 +102,7 @@ func runWizard(opts wizardOpts) error {
 // runNonInteractive handles the --api-key flag path with no prompts.
 func runNonInteractive(opts wizardOpts, status SetupStatus) error {
 	if status.HasAPIKey {
-		_, _ = common.Green.Println("  ✓ API key already configured")
-		stepGrantSync(&status)
-		printComplete()
-		return nil
+		_, _ = common.Yellow.Println("  Updating existing API key configuration")
 	}
 
 	region := opts.region
@@ -107,7 +115,7 @@ func runNonInteractive(opts wizardOpts, status SetupStatus) error {
 	fmt.Println()
 	var verifyErr error
 	_ = common.RunWithSpinner("Verifying API key...", func() error {
-		verifyErr = verifyAPIKey(apiKey, region)
+		verifyErr = verifyAPIKeyFn(apiKey, region)
 		return verifyErr
 	})
 	if verifyErr != nil {
@@ -116,16 +124,25 @@ func runNonInteractive(opts wizardOpts, status SetupStatus) error {
 	}
 	_, _ = common.Green.Println("  ✓ API key is valid")
 
-	if err := dashboard.ActivateAPIKey(apiKey, "", region); err != nil {
+	selection, err := resolveAPIKeyApplicationFn(apiKey, region, opts.clientID, false)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureSetupCallbackURIFn(apiKey, selection.ClientID, region); err != nil {
+		return err
+	}
+
+	if err := activateAPIKeyFn(apiKey, selection.ClientID, region, selection.OrgID); err != nil {
 		common.PrintError("Could not activate API key: %v", err)
 		return err
 	}
 	_, _ = common.Green.Println("  ✓ Configuration saved")
 
 	// Refresh status after activation.
-	status = GetSetupStatus()
-	stepGrantSync(&status)
-	printComplete()
+	status = getSetupStatusFn()
+	stepGrantSyncFn(&status)
+	printCompleteFn()
 	return nil
 }
 
@@ -157,7 +174,7 @@ func stepAccount(opts wizardOpts, status *SetupStatus) error {
 	case pathLogin:
 		return accountSSO(opts, "login")
 	case pathAPIKey:
-		return accountAPIKey(status)
+		return accountAPIKey(opts, status)
 	}
 	return nil
 }
@@ -197,7 +214,7 @@ func accountSSO(opts wizardOpts, mode string) error {
 }
 
 // accountAPIKey handles the "I have an API key" path.
-func accountAPIKey(status *SetupStatus) error {
+func accountAPIKey(opts wizardOpts, status *SetupStatus) error {
 	apiKeyRaw, err := common.PasswordPrompt("API Key")
 	if err != nil {
 		return fmt.Errorf("failed to read API key: %w", err)
@@ -226,7 +243,14 @@ func accountAPIKey(status *SetupStatus) error {
 		return verifyErr
 	}
 
-	if err := dashboard.ActivateAPIKey(apiKey, "", region); err != nil {
+	selection, err := ResolveAPIKeyApplication(apiKey, region, opts.clientID, true)
+	if err != nil {
+		return err
+	}
+	if err := ensureSetupCallbackURI(apiKey, selection.ClientID, region); err != nil {
+		return err
+	}
+	if err := dashboard.ActivateAPIKey(apiKey, selection.ClientID, region, selection.OrgID); err != nil {
 		return fmt.Errorf("could not activate API key: %w", err)
 	}
 
@@ -352,7 +376,10 @@ func stepAPIKey(status *SetupStatus) error {
 
 	// Activate the key directly (no 3-option menu in the wizard).
 	err = common.RunWithSpinner("Activating API key...", func() error {
-		return dashboard.ActivateAPIKey(key.APIKey, status.ActiveAppID, status.ActiveAppRegion)
+		if err := ensureSetupCallbackURI(key.APIKey, status.ActiveAppID, status.ActiveAppRegion); err != nil {
+			return err
+		}
+		return dashboard.ActivateAPIKey(key.APIKey, status.ActiveAppID, status.ActiveAppRegion, "")
 	})
 	if err != nil {
 		return err

--- a/internal/cli/setup/wizard_helpers.go
+++ b/internal/cli/setup/wizard_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nylas/cli/internal/adapters/config"
 	nylasadapter "github.com/nylas/cli/internal/adapters/nylas"
 	dashboardapp "github.com/nylas/cli/internal/app/dashboard"
 	"github.com/nylas/cli/internal/cli/common"
@@ -11,6 +12,8 @@ import (
 	"github.com/nylas/cli/internal/domain"
 	"github.com/nylas/cli/internal/ports"
 )
+
+var setupCallbackProvisioner = EnsureOAuthCallbackURI
 
 // printComplete prints the final success message.
 func printComplete() {
@@ -156,6 +159,44 @@ func verifyAPIKey(apiKey, region string) error {
 
 	_, err := client.ListApplications(ctx)
 	return err
+}
+
+func ensureSetupCallbackURI(apiKey, clientID, region string) error {
+	if strings.TrimSpace(clientID) == "" {
+		return fmt.Errorf("client ID is required to configure the OAuth callback URI")
+	}
+
+	configStore := config.NewDefaultFileStore()
+	cfg, err := configStore.Load()
+	if err != nil || cfg == nil {
+		cfg = domain.DefaultConfig()
+	}
+
+	result, err := setupCallbackProvisioner(apiKey, clientID, region, cfg.CallbackPort)
+	if err != nil {
+		printCallbackURIManualInstructions(result.RequiredURI, err)
+		return nil
+	}
+
+	switch {
+	case result.AlreadyExists:
+		_, _ = common.Green.Println("  ✓ Callback URI already configured")
+	case result.Created:
+		_, _ = common.Green.Printf("  ✓ Added callback URI: %s\n", result.RequiredURI)
+	}
+
+	return nil
+}
+
+func printCallbackURIManualInstructions(requiredCallbackURI string, err error) {
+	fmt.Println()
+	fmt.Println("Setting up callback URI for OAuth authentication...")
+	_, _ = common.Yellow.Printf("  Could not add callback URI automatically: %v\n", err)
+	fmt.Printf("  Please add this callback URI manually in the Nylas dashboard:\n")
+	fmt.Printf("    %s\n", requiredCallbackURI)
+	fmt.Println()
+	fmt.Printf("  Dashboard: https://dashboard.nylas.com/applications\n")
+	fmt.Printf("  Navigate to: Your App → Settings → Callback URIs → Add URI\n")
 }
 
 // sanitizeAPIKey removes invisible characters from a pasted API key.

--- a/internal/cli/setup/wizard_helpers_test.go
+++ b/internal/cli/setup/wizard_helpers_test.go
@@ -1,0 +1,29 @@
+package setup
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEnsureSetupCallbackURI_AllowsManualFallbackWhenProvisioningFails(t *testing.T) {
+	originalProvisioner := setupCallbackProvisioner
+	t.Cleanup(func() {
+		setupCallbackProvisioner = originalProvisioner
+	})
+
+	setupCallbackProvisioner = func(apiKey, clientID, region string, callbackPort int) (*CallbackURIProvisionResult, error) {
+		return &CallbackURIProvisionResult{
+			RequiredURI: "http://localhost:9007/callback",
+		}, errors.New("admin api unavailable")
+	}
+
+	if err := ensureSetupCallbackURI("nyl_test", "client-123", "us"); err != nil {
+		t.Fatalf("expected setup callback URI failure to degrade gracefully, got %v", err)
+	}
+}
+
+func TestEnsureSetupCallbackURI_RequiresClientID(t *testing.T) {
+	if err := ensureSetupCallbackURI("nyl_test", "", "us"); err == nil {
+		t.Fatal("expected empty client ID to fail")
+	}
+}

--- a/internal/cli/setup/wizard_noninteractive_test.go
+++ b/internal/cli/setup/wizard_noninteractive_test.go
@@ -1,0 +1,123 @@
+package setup
+
+import "testing"
+
+func TestRunNonInteractive_ReconfiguresExistingAPIKey(t *testing.T) {
+	originalVerify := verifyAPIKeyFn
+	originalResolve := resolveAPIKeyApplicationFn
+	originalEnsureCallback := ensureSetupCallbackURIFn
+	originalActivate := activateAPIKeyFn
+	originalGetStatus := getSetupStatusFn
+	originalStepGrantSync := stepGrantSyncFn
+	originalPrintComplete := printCompleteFn
+	t.Cleanup(func() {
+		verifyAPIKeyFn = originalVerify
+		resolveAPIKeyApplicationFn = originalResolve
+		ensureSetupCallbackURIFn = originalEnsureCallback
+		activateAPIKeyFn = originalActivate
+		getSetupStatusFn = originalGetStatus
+		stepGrantSyncFn = originalStepGrantSync
+		printCompleteFn = originalPrintComplete
+	})
+
+	verifyCalls := 0
+	verifyAPIKeyFn = func(apiKey, region string) error {
+		verifyCalls++
+		if apiKey != "nyl_new_key" {
+			t.Fatalf("expected api key %q, got %q", "nyl_new_key", apiKey)
+		}
+		if region != "eu" {
+			t.Fatalf("expected region %q, got %q", "eu", region)
+		}
+		return nil
+	}
+
+	resolveCalls := 0
+	resolveAPIKeyApplicationFn = func(apiKey, region, explicitClientID string, interactive bool) (*APIKeyApplication, error) {
+		resolveCalls++
+		if interactive {
+			t.Fatal("expected non-interactive application resolution")
+		}
+		if explicitClientID != "client-123" {
+			t.Fatalf("expected client ID %q, got %q", "client-123", explicitClientID)
+		}
+		return &APIKeyApplication{ClientID: "client-123", OrgID: "org-456"}, nil
+	}
+
+	callbackCalls := 0
+	ensureSetupCallbackURIFn = func(apiKey, clientID, region string) error {
+		callbackCalls++
+		if clientID != "client-123" {
+			t.Fatalf("expected callback setup client ID %q, got %q", "client-123", clientID)
+		}
+		return nil
+	}
+
+	activateCalls := 0
+	activateAPIKeyFn = func(apiKey, clientID, region, orgID string) error {
+		activateCalls++
+		if apiKey != "nyl_new_key" {
+			t.Fatalf("expected activated api key %q, got %q", "nyl_new_key", apiKey)
+		}
+		if clientID != "client-123" {
+			t.Fatalf("expected activated client ID %q, got %q", "client-123", clientID)
+		}
+		if region != "eu" {
+			t.Fatalf("expected activated region %q, got %q", "eu", region)
+		}
+		if orgID != "org-456" {
+			t.Fatalf("expected activated org ID %q, got %q", "org-456", orgID)
+		}
+		return nil
+	}
+
+	getStatusCalls := 0
+	getSetupStatusFn = func() SetupStatus {
+		getStatusCalls++
+		return SetupStatus{HasAPIKey: true}
+	}
+
+	grantSyncCalls := 0
+	stepGrantSyncFn = func(status *SetupStatus) {
+		grantSyncCalls++
+		if status == nil || !status.HasAPIKey {
+			t.Fatal("expected refreshed status with API key configured")
+		}
+	}
+
+	printCompleteCalls := 0
+	printCompleteFn = func() {
+		printCompleteCalls++
+	}
+
+	err := runNonInteractive(wizardOpts{
+		apiKey:   "nyl_new_key",
+		clientID: "client-123",
+		region:   "eu",
+	}, SetupStatus{HasAPIKey: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if verifyCalls != 1 {
+		t.Fatalf("expected verify to run once, got %d", verifyCalls)
+	}
+	if resolveCalls != 1 {
+		t.Fatalf("expected application resolution once, got %d", resolveCalls)
+	}
+	if callbackCalls != 1 {
+		t.Fatalf("expected callback setup once, got %d", callbackCalls)
+	}
+	if activateCalls != 1 {
+		t.Fatalf("expected activation once, got %d", activateCalls)
+	}
+	if getStatusCalls != 1 {
+		t.Fatalf("expected status refresh once, got %d", getStatusCalls)
+	}
+	if grantSyncCalls != 1 {
+		t.Fatalf("expected grant sync once, got %d", grantSyncCalls)
+	}
+	if printCompleteCalls != 1 {
+		t.Fatalf("expected completion message once, got %d", printCompleteCalls)
+	}
+}

--- a/internal/ui/server_config.go
+++ b/internal/ui/server_config.go
@@ -1,11 +1,15 @@
 package ui
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	nylasadapter "github.com/nylas/cli/internal/adapters/nylas"
+	authapp "github.com/nylas/cli/internal/app/auth"
 	"github.com/nylas/cli/internal/cli/common"
+	setupcli "github.com/nylas/cli/internal/cli/setup"
 	"github.com/nylas/cli/internal/domain"
 )
 
@@ -57,14 +61,17 @@ func (s *Server) handleConfigStatus(w http.ResponseWriter, r *http.Request) {
 
 // SetupRequest represents the setup API request.
 type SetupRequest struct {
-	APIKey string `json:"api_key"`
-	Region string `json:"region"`
+	APIKey   string `json:"api_key"`
+	Region   string `json:"region"`
+	ClientID string `json:"client_id,omitempty"`
 }
 
 // SetupResponse represents the setup API response.
 type SetupResponse struct {
 	Success      bool          `json:"success"`
 	Message      string        `json:"message"`
+	Warning      string        `json:"warning,omitempty"`
+	Region       string        `json:"region,omitempty"`
 	ClientID     string        `json:"client_id,omitempty"`
 	Applications []Application `json:"applications,omitempty"`
 	Grants       []Grant       `json:"grants,omitempty"`
@@ -84,6 +91,20 @@ type Grant struct {
 	Email    string `json:"email"`
 	Provider string `json:"provider"`
 }
+
+type setupClient interface {
+	ListApplications(ctx context.Context) ([]domain.Application, error)
+	ListGrants(ctx context.Context) ([]domain.Grant, error)
+}
+
+var newSetupClient = func(region, clientID, apiKey string) setupClient {
+	client := nylasadapter.NewHTTPClient()
+	client.SetRegion(region)
+	client.SetCredentials(clientID, "", apiKey)
+	return client
+}
+
+var ensureSetupCallbackURI = setupcli.EnsureOAuthCallbackURI
 
 // grantFromDomain converts a domain.GrantInfo to a Grant for API responses.
 func grantFromDomain(g domain.GrantInfo) Grant {
@@ -105,6 +126,7 @@ func (s *Server) handleConfigSetup(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, SetupResponse{
 			Success:  true,
 			Message:  "Demo mode - configuration simulated",
+			Region:   "us",
 			ClientID: "demo-client-id",
 			Applications: []Application{
 				{ID: "demo-app", Name: "Demo Application", Environment: "production"},
@@ -136,9 +158,7 @@ func (s *Server) handleConfigSetup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create Nylas client to detect applications
-	client := nylasadapter.NewHTTPClient()
-	client.SetRegion(req.Region)
-	client.SetCredentials("", "", req.APIKey)
+	client := newSetupClient(req.Region, "", req.APIKey)
 
 	ctx, cancel := common.CreateContext()
 	defer cancel()
@@ -161,13 +181,30 @@ func (s *Server) handleConfigSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use the first application's Client ID and Org ID
-	app := apps[0]
-	clientID := app.ApplicationID
-	if clientID == "" {
-		clientID = app.ID
+	appList := buildApplicationList(apps)
+	selectedApp, err := resolveSetupApplication(apps, req.ClientID)
+	if err != nil {
+		writeJSON(w, http.StatusConflict, SetupResponse{
+			Success:      false,
+			Error:        err.Error(),
+			Applications: appList,
+		})
+		return
 	}
-	orgID := app.OrganizationID
+
+	clientID := setupcli.AppClientID(*selectedApp)
+	orgID := selectedApp.OrganizationID
+
+	cfg, err := s.configStore.Load()
+	if err != nil || cfg == nil {
+		cfg = domain.DefaultConfig()
+	}
+
+	warning := ""
+	callbackResult, callbackErr := ensureSetupCallbackURI(req.APIKey, clientID, req.Region, cfg.CallbackPort)
+	if callbackErr != nil {
+		warning = fmt.Sprintf("Add callback URI manually in the dashboard: %s", callbackResult.RequiredURI)
+	}
 
 	// Save configuration
 	if err := s.configSvc.SetupConfig(req.Region, clientID, "", req.APIKey, orgID); err != nil {
@@ -179,14 +216,15 @@ func (s *Server) handleConfigSetup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update client with credentials for grant lookup
-	client.SetCredentials(clientID, "", req.APIKey)
+	client = newSetupClient(req.Region, clientID, req.APIKey)
 
 	// Fetch existing grants
 	grants, _ := client.ListGrants(ctx)
 
 	// Save grants locally
 	var grantList []Grant
-	for i, grant := range grants {
+	defaultAssigned := false
+	for _, grant := range grants {
 		if !grant.IsValid() {
 			continue
 		}
@@ -199,35 +237,62 @@ func (s *Server) handleConfigSetup(w http.ResponseWriter, r *http.Request) {
 
 		_ = s.grantStore.SaveGrant(grantInfo)
 
-		// Set first grant as default
-		if i == 0 {
-			_ = s.grantStore.SetDefaultGrant(grant.ID)
+		if !defaultAssigned {
+			if err := authapp.PersistDefaultGrant(s.configStore, s.grantStore, grant.ID); err != nil {
+				writeJSON(w, http.StatusInternalServerError, SetupResponse{
+					Success: false,
+					Error:   "Failed to set default grant: " + err.Error(),
+				})
+				return
+			}
+			defaultAssigned = true
 		}
 
 		grantList = append(grantList, grantFromDomain(grantInfo))
 	}
 
-	// Build response
-	var appList []Application
-	for _, a := range apps {
-		id := a.ApplicationID
-		if id == "" {
-			id = a.ID
-		}
-		appList = append(appList, Application{
-			ID:          id,
-			Name:        id, // Use ID as name since Application struct doesn't have Name field
-			Environment: a.Environment,
-		})
-	}
-
 	writeJSON(w, http.StatusOK, SetupResponse{
 		Success:      true,
 		Message:      "Configuration saved successfully",
+		Warning:      warning,
+		Region:       req.Region,
 		ClientID:     clientID,
 		Applications: appList,
 		Grants:       grantList,
 	})
+}
+
+func buildApplicationList(apps []domain.Application) []Application {
+	appList := make([]Application, 0, len(apps))
+	for _, app := range apps {
+		id := setupcli.AppClientID(app)
+		appList = append(appList, Application{
+			ID:          id,
+			Name:        id,
+			Environment: app.Environment,
+		})
+	}
+	return appList
+}
+
+func resolveSetupApplication(apps []domain.Application, requestedClientID string) (*domain.Application, error) {
+	if len(apps) == 0 {
+		return nil, fmt.Errorf("no applications found for this API key")
+	}
+	if requestedClientID == "" {
+		if len(apps) > 1 {
+			return nil, fmt.Errorf("multiple applications found for this API key; provide client_id to select one")
+		}
+		return &apps[0], nil
+	}
+
+	for i := range apps {
+		if setupcli.AppClientID(apps[i]) == requestedClientID {
+			return &apps[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("client_id %q was not found for this API key", requestedClientID)
 }
 
 // GrantsResponse represents the grants list API response.

--- a/internal/ui/server_grants.go
+++ b/internal/ui/server_grants.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"slices"
 
+	authapp "github.com/nylas/cli/internal/app/auth"
 	"github.com/nylas/cli/internal/domain"
 )
 
@@ -109,7 +110,7 @@ func (s *Server) handleSetDefaultGrant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.grantStore.SetDefaultGrant(req.GrantID); err != nil {
+	if err := authapp.PersistDefaultGrant(s.configStore, s.grantStore, req.GrantID); err != nil {
 		writeJSON(w, http.StatusInternalServerError, SetDefaultGrantResponse{
 			Success: false,
 			Error:   "Failed to set default grant: " + err.Error(),

--- a/internal/ui/server_handlers_test.go
+++ b/internal/ui/server_handlers_test.go
@@ -2,11 +2,18 @@ package ui
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	configadapter "github.com/nylas/cli/internal/adapters/config"
+	keyringadapter "github.com/nylas/cli/internal/adapters/keyring"
+	authapp "github.com/nylas/cli/internal/app/auth"
+	setupcli "github.com/nylas/cli/internal/cli/setup"
+	"github.com/nylas/cli/internal/domain"
 )
 
 // =============================================================================
@@ -236,6 +243,204 @@ func TestHandleConfigSetup_EmptyAPIKey(t *testing.T) {
 
 	if !strings.Contains(resp.Error, "API key") {
 		t.Errorf("Expected API key error, got: %s", resp.Error)
+	}
+}
+
+type stubSetupClient struct {
+	apps   []domain.Application
+	grants []domain.Grant
+}
+
+func (s *stubSetupClient) ListApplications(context.Context) ([]domain.Application, error) {
+	return s.apps, nil
+}
+
+func (s *stubSetupClient) ListGrants(context.Context) ([]domain.Grant, error) {
+	return s.grants, nil
+}
+
+func TestHandleConfigSetup_RequiresExplicitClientIDWhenMultipleAppsExist(t *testing.T) {
+	originalClientFactory := newSetupClient
+	originalCallbackSetup := ensureSetupCallbackURI
+	t.Cleanup(func() {
+		newSetupClient = originalClientFactory
+		ensureSetupCallbackURI = originalCallbackSetup
+	})
+
+	newSetupClient = func(region, clientID, apiKey string) setupClient {
+		return &stubSetupClient{
+			apps: []domain.Application{
+				{ApplicationID: "client-1", OrganizationID: "org-1", Environment: "production"},
+				{ApplicationID: "client-2", OrganizationID: "org-2", Environment: "sandbox"},
+			},
+		}
+	}
+	ensureSetupCallbackURI = func(apiKey, clientID, region string, callbackPort int) (*setupcli.CallbackURIProvisionResult, error) {
+		t.Fatal("did not expect callback setup without an explicit client selection")
+		return nil, nil
+	}
+
+	server := &Server{
+		configStore: configadapter.NewMockConfigStore(),
+		secretStore: keyringadapter.NewMockSecretStore(),
+		grantStore:  keyringadapter.NewGrantStore(keyringadapter.NewMockSecretStore()),
+	}
+	server.configSvc = authapp.NewConfigService(server.configStore, server.secretStore)
+
+	body, _ := json.Marshal(SetupRequest{APIKey: "nyl_test", Region: "us"})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/setup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.handleConfigSetup(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected status %d, got %d", http.StatusConflict, w.Code)
+	}
+
+	var resp SetupResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(resp.Applications) != 2 {
+		t.Fatalf("expected two applications in response, got %d", len(resp.Applications))
+	}
+	if !strings.Contains(resp.Error, "client_id") {
+		t.Fatalf("expected client_id guidance, got %q", resp.Error)
+	}
+}
+
+func TestHandleConfigSetup_ReturnsWarningWhenCallbackSetupFails(t *testing.T) {
+	originalClientFactory := newSetupClient
+	originalCallbackSetup := ensureSetupCallbackURI
+	t.Cleanup(func() {
+		newSetupClient = originalClientFactory
+		ensureSetupCallbackURI = originalCallbackSetup
+	})
+
+	newSetupClient = func(region, clientID, apiKey string) setupClient {
+		return &stubSetupClient{
+			apps: []domain.Application{
+				{ApplicationID: "client-1", OrganizationID: "org-1", Environment: "production"},
+			},
+			grants: []domain.Grant{
+				{ID: "grant-1", Email: "user@example.com", Provider: domain.ProviderGoogle, GrantStatus: "valid"},
+			},
+		}
+	}
+	ensureSetupCallbackURI = func(apiKey, clientID, region string, callbackPort int) (*setupcli.CallbackURIProvisionResult, error) {
+		return &setupcli.CallbackURIProvisionResult{
+			RequiredURI: "http://localhost:9007/callback",
+		}, context.DeadlineExceeded
+	}
+
+	configStore := configadapter.NewMockConfigStore()
+	secretStore := keyringadapter.NewMockSecretStore()
+	server := &Server{
+		configStore: configStore,
+		secretStore: secretStore,
+		grantStore:  keyringadapter.NewGrantStore(secretStore),
+	}
+	server.configSvc = authapp.NewConfigService(configStore, secretStore)
+
+	body, _ := json.Marshal(SetupRequest{APIKey: "nyl_test", Region: "us", ClientID: "client-1"})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/setup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.handleConfigSetup(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var resp SetupResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if !resp.Success {
+		t.Fatalf("expected success response, got error %q", resp.Error)
+	}
+	if !strings.Contains(resp.Warning, "callback") {
+		t.Fatalf("expected callback warning, got %q", resp.Warning)
+	}
+	if resp.Region != "us" {
+		t.Fatalf("expected region %q, got %q", "us", resp.Region)
+	}
+	if resp.ClientID != "client-1" {
+		t.Fatalf("expected client ID %q, got %q", "client-1", resp.ClientID)
+	}
+	if len(resp.Grants) != 1 {
+		t.Fatalf("expected one synced grant, got %d", len(resp.Grants))
+	}
+}
+
+func TestHandleConfigSetup_PersistsFirstValidGrantAsDefault(t *testing.T) {
+	originalClientFactory := newSetupClient
+	originalCallbackSetup := ensureSetupCallbackURI
+	t.Cleanup(func() {
+		newSetupClient = originalClientFactory
+		ensureSetupCallbackURI = originalCallbackSetup
+	})
+
+	newSetupClient = func(region, clientID, apiKey string) setupClient {
+		return &stubSetupClient{
+			apps: []domain.Application{
+				{ApplicationID: "client-1", OrganizationID: "org-1", Environment: "production"},
+			},
+			grants: []domain.Grant{
+				{ID: "grant-revoked", Email: "revoked@example.com", Provider: domain.ProviderGoogle, GrantStatus: "revoked"},
+				{ID: "grant-valid", Email: "valid@example.com", Provider: domain.ProviderGoogle, GrantStatus: "valid"},
+			},
+		}
+	}
+	ensureSetupCallbackURI = func(apiKey, clientID, region string, callbackPort int) (*setupcli.CallbackURIProvisionResult, error) {
+		return &setupcli.CallbackURIProvisionResult{}, nil
+	}
+
+	configStore := configadapter.NewMockConfigStore()
+	secretStore := keyringadapter.NewMockSecretStore()
+	server := &Server{
+		configStore: configStore,
+		secretStore: secretStore,
+		grantStore:  keyringadapter.NewGrantStore(secretStore),
+	}
+	server.configSvc = authapp.NewConfigService(configStore, secretStore)
+
+	body, _ := json.Marshal(SetupRequest{APIKey: "nyl_test", Region: "eu", ClientID: "client-1"})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/setup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.handleConfigSetup(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var resp SetupResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Region != "eu" {
+		t.Fatalf("expected region %q, got %q", "eu", resp.Region)
+	}
+	if len(resp.Grants) != 1 {
+		t.Fatalf("expected one valid grant in response, got %d", len(resp.Grants))
+	}
+	if resp.Grants[0].ID != "grant-valid" {
+		t.Fatalf("expected valid grant to be returned, got %q", resp.Grants[0].ID)
+	}
+
+	defaultGrant, err := server.grantStore.GetDefaultGrant()
+	if err != nil {
+		t.Fatalf("get default grant: %v", err)
+	}
+	if defaultGrant != "grant-valid" {
+		t.Fatalf("expected default grant %q, got %q", "grant-valid", defaultGrant)
 	}
 }
 

--- a/internal/ui/static/css/components-forms.css
+++ b/internal/ui/static/css/components-forms.css
@@ -206,6 +206,17 @@
     margin-bottom: 8px;
 }
 
+.field.is-hidden {
+    display: none;
+}
+
+.setup-help {
+    margin-top: 10px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-muted);
+}
+
 .input-wrapper,
 .select-wrapper {
     position: relative;
@@ -288,6 +299,24 @@
 }
 
 .error-msg.visible { display: block; }
+
+.warning-msg {
+    display: none;
+    padding: 14px 16px;
+    margin-bottom: 20px;
+    background: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.3);
+    border-radius: 10px;
+    color: #fbbf24;
+    font-size: 14px;
+    text-align: left;
+}
+
+.warning-msg.visible { display: block; }
+
+.overview-warning {
+    margin-bottom: 24px;
+}
 
 /* Primary Button */
 .btn-primary {

--- a/internal/ui/static/js/dropdowns.js
+++ b/internal/ui/static/js/dropdowns.js
@@ -29,13 +29,13 @@ function updateHeaderDropdowns() {
     controls.style.display = 'flex';
 
     // Update app dropdown
-    const appSpan = document.getElementById('current-app');
+    const appSpan = document.getElementById('selected-client');
     if (appSpan && currentConfig.client_id) {
         appSpan.textContent = currentConfig.client_id;
     }
 
     // Update app menu
-    const appMenu = document.getElementById('app-menu');
+    const appMenu = document.getElementById('client-menu');
     if (appMenu && currentConfig.client_id) {
         appMenu.innerHTML = `
             <button class="dropdown-item active">
@@ -53,8 +53,8 @@ function updateHeaderDropdowns() {
 }
 
 function updateAccountDropdown() {
-    const accountSpan = document.getElementById('current-account');
-    const accountMenu = document.getElementById('account-menu');
+    const accountSpan = document.getElementById('selected-grant');
+    const accountMenu = document.getElementById('grant-menu');
 
     if (!accountSpan || !accountMenu) return;
 
@@ -62,9 +62,9 @@ function updateAccountDropdown() {
     const defaultAccount = currentGrants.find(g => g.id === currentDefaultGrant);
 
     if (defaultAccount) {
-        accountSpan.textContent = defaultAccount.id;
+        accountSpan.textContent = defaultAccount.email || defaultAccount.id;
     } else if (currentGrants.length > 0) {
-        accountSpan.textContent = currentGrants[0].id;
+        accountSpan.textContent = currentGrants[0].email || currentGrants[0].id;
     } else {
         accountSpan.textContent = 'None';
     }
@@ -121,4 +121,12 @@ function showAddAccount() {
 
     // Show a simple alert with the command
     alert('Run this command in your terminal:\n\nnylas auth login');
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        toggleDropdown,
+        updateAccountDropdown,
+        updateHeaderDropdowns,
+    };
 }

--- a/internal/ui/static/js/form.js
+++ b/internal/ui/static/js/form.js
@@ -2,14 +2,25 @@
 // Setup Form
 // =============================================================================
 
+function getSetupErrorElement(doc = document) {
+    return doc.getElementById('setup-error') || doc.getElementById('error-msg');
+}
+
 function initForm() {
     const form = document.getElementById('setup-form');
     if (!form) return;
 
+    document.getElementById('api-key')?.addEventListener('input', () => {
+        resetApplicationSelection();
+    });
+    document.getElementById('region')?.addEventListener('change', () => {
+        resetApplicationSelection();
+    });
+
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
         const btn = form.querySelector('.btn-primary');
-        const error = document.getElementById('error-msg');
+        const error = getSetupErrorElement();
 
         error?.classList.remove('visible');
         btn.classList.add('loading');
@@ -19,18 +30,10 @@ function initForm() {
             const res = await fetch('/api/config/setup', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    api_key: document.getElementById('api-key').value.trim(),
-                    region: document.getElementById('region').value
-                })
+                body: JSON.stringify(buildSetupPayload())
             });
             const data = await res.json();
-
-            if (data.success) {
-                showDashboard(data);
-            } else {
-                showFormError(data.error || 'Setup failed');
-            }
+            handleSetupResult(data, res.status);
         } catch (err) {
             showFormError('Connection failed. Please try again.');
         } finally {
@@ -40,12 +43,150 @@ function initForm() {
     });
 }
 
-function showFormError(msg) {
-    const error = document.getElementById('error-msg');
+function buildSetupPayload(doc = document) {
+    const payload = {
+        api_key: doc.getElementById('api-key')?.value.trim() || '',
+        region: doc.getElementById('region')?.value || 'us',
+    };
+
+    const clientID = getSelectedClientID(doc);
+    if (clientID) {
+        payload.client_id = clientID;
+    }
+
+    return payload;
+}
+
+function getSelectedClientID(doc = document) {
+    const field = doc.getElementById('client-id-field');
+    const select = doc.getElementById('client-id');
+    if (!field || !select || field.classList.contains('is-hidden')) return '';
+    return select.value.trim();
+}
+
+function shouldShowApplicationSelection(status, data) {
+    return status === 409 && Array.isArray(data?.applications) && data.applications.length > 0;
+}
+
+function formatApplicationLabel(app) {
+    const name = app?.name || app?.id || 'Unknown application';
+    const environment = app?.environment || 'production';
+    return `${name} (${environment})`;
+}
+
+function handleSetupResult(data, status, deps = {}) {
+    const showDashboardFn = deps.showDashboard || (typeof showDashboard === 'function' ? showDashboard : () => {});
+    const showToastFn = deps.showToast || (typeof showToast === 'function' ? showToast : () => {});
+
+    if (data?.success) {
+        clearFormError();
+        resetApplicationSelection();
+        showDashboardFn(data);
+        syncDashboardSummary(data);
+
+        if (data.warning) {
+            displaySetupWarning(data.warning);
+            showToastFn(data.warning, 'info');
+        } else {
+            clearSetupWarning();
+        }
+        return;
+    }
+
+    clearSetupWarning();
+    if (shouldShowApplicationSelection(status, data)) {
+        showApplicationSelection(data.applications, data.error || 'Choose an application to continue.');
+        return;
+    }
+
+    showFormError(data?.error || 'Setup failed');
+}
+
+function showApplicationSelection(applications, message, doc = document) {
+    const field = doc.getElementById('client-id-field');
+    const select = doc.getElementById('client-id');
+    const btn = doc.getElementById('setup-btn');
+    if (!field || !select) {
+        showFormError(message);
+        return;
+    }
+
+    select.innerHTML = applications.map((app) => (
+        `<option value="${esc(app.id)}">${esc(formatApplicationLabel(app))}</option>`
+    )).join('');
+
+    if (applications[0]?.id) {
+        select.value = applications[0].id;
+    }
+
+    field.classList.remove('is-hidden');
+    btn && (btn.textContent = 'Connect Selected Application');
+    showFormError(message);
+    if (typeof select.focus === 'function') {
+        select.focus();
+    }
+}
+
+function resetApplicationSelection(doc = document) {
+    const field = doc.getElementById('client-id-field');
+    const select = doc.getElementById('client-id');
+    const btn = doc.getElementById('setup-btn');
+
+    if (field) {
+        field.classList.add('is-hidden');
+    }
+    if (select) {
+        select.innerHTML = '';
+        select.value = '';
+    }
+    if (btn) {
+        btn.textContent = 'Connect Account';
+    }
+    clearFormError(doc);
+}
+
+function syncDashboardSummary(data, doc = document) {
+    const regionEl = doc.getElementById('config-region');
+    const clientEl = doc.getElementById('config-client');
+    if (regionEl) {
+        regionEl.textContent = (data?.region || 'us').toUpperCase();
+    }
+    if (clientEl) {
+        const clientID = data?.client_id || '';
+        clientEl.textContent = clientID ? truncate(clientID, 16) : '-';
+    }
+}
+
+function showFormError(msg, doc = document) {
+    const error = getSetupErrorElement(doc);
     if (error) {
         error.textContent = msg;
         error.classList.add('visible');
     }
+}
+
+function clearFormError(doc = document) {
+    const error = getSetupErrorElement(doc);
+    if (error) {
+        error.textContent = '';
+        error.classList.remove('visible');
+    }
+}
+
+function displaySetupWarning(msg, doc = document) {
+    const warning = doc.getElementById('setup-warning-banner');
+    if (!warning) return;
+
+    warning.textContent = msg;
+    warning.classList.add('visible');
+}
+
+function clearSetupWarning(doc = document) {
+    const warning = doc.getElementById('setup-warning-banner');
+    if (!warning) return;
+
+    warning.textContent = '';
+    warning.classList.remove('visible');
 }
 
 function togglePassword() {
@@ -54,4 +195,22 @@ function togglePassword() {
     const isPassword = input.type === 'password';
     input.type = isPassword ? 'text' : 'password';
     btn?.classList.toggle('visible', isPassword);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        buildSetupPayload,
+        clearFormError,
+        clearSetupWarning,
+        displaySetupWarning,
+        formatApplicationLabel,
+        getSelectedClientID,
+        handleSetupResult,
+        resetApplicationSelection,
+        shouldShowApplicationSelection,
+        showApplicationSelection,
+        showFormError,
+        syncDashboardSummary,
+        togglePassword,
+    };
 }

--- a/internal/ui/static/js/state.js
+++ b/internal/ui/static/js/state.js
@@ -41,8 +41,8 @@ function showDashboard(data) {
     };
 
     const region = currentConfig.region.toUpperCase();
-    setText('cfg-region', region);
-    setText('cfg-client', truncate(currentConfig.client_id, 16) || '-');
+    setText('config-region', region);
+    setText('config-client', truncate(currentConfig.client_id, 16) || '-');
 
     loadAccounts();
 }

--- a/internal/ui/templates/pages/overview.gohtml
+++ b/internal/ui/templates/pages/overview.gohtml
@@ -11,6 +11,8 @@
         </div>
     </div>
 
+    <div class="warning-msg overview-warning" id="setup-warning-banner"></div>
+
     <div class="dashboard-grid three-col">
         <!-- Configuration Card -->
         <div class="glass-card card">

--- a/internal/ui/templates/partials/content.gohtml
+++ b/internal/ui/templates/partials/content.gohtml
@@ -14,14 +14,14 @@
                 <p>Connect your Nylas account to get started</p>
             </div>
 
-            <div class="setup-form">
+            <form class="setup-form" id="setup-form">
                 <div class="error-msg" id="setup-error"></div>
 
                 <div class="field">
                     <label for="api-key">API Key</label>
                     <div class="input-wrapper">
                         <input type="password" id="api-key" placeholder="nyk_v0_...">
-                        <button class="input-btn" onclick="toggleApiKeyVisibility()">
+                        <button type="button" class="input-btn" onclick="togglePassword()">
                             <svg class="eye-open" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
                                 <circle cx="12" cy="12" r="3"/>
@@ -47,10 +47,21 @@
                     </div>
                 </div>
 
-                <button class="btn-primary" id="setup-btn" onclick="submitSetup()">
+                <div class="field is-hidden" id="client-id-field">
+                    <label for="client-id">Application</label>
+                    <div class="select-wrapper">
+                        <select id="client-id"></select>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="6 9 12 15 18 9"/>
+                        </svg>
+                    </div>
+                    <p class="setup-help">This API key is linked to multiple applications. Choose the application to configure.</p>
+                </div>
+
+                <button type="submit" class="btn-primary" id="setup-btn">
                     Connect Account
                 </button>
-            </div>
+            </form>
         </div>
     </section>
 

--- a/tests/air/e2e/email-operations-folders.spec.js
+++ b/tests/air/e2e/email-operations-folders.spec.js
@@ -82,6 +82,15 @@ test.describe('Folder Navigation', () => {
     }
   });
 
+  test('Archive folder is visible inline without a More dropdown', async ({ page }) => {
+    const folderList = page.locator(selectors.email.folderList);
+
+    await page.waitForTimeout(2000);
+
+    await expect(folderList.locator('.folder-item:has-text("Archive")')).toBeVisible();
+    await expect(folderList.locator('.folder-item:has-text("More")')).toHaveCount(0);
+  });
+
   test('folders show unread count badge', async ({ page }) => {
     const folderList = page.locator(selectors.email.folderList);
     const folders = folderList.locator(selectors.email.folderItem);
@@ -98,4 +107,3 @@ test.describe('Folder Navigation', () => {
     }
   });
 });
-


### PR DESCRIPTION
## Summary
- harden Air request handling with tighter middleware protections and safer smart compose process execution
- preserve and repair auth/setup state across CLI, dashboard, and web onboarding flows, including callback provisioning and grant reset handling
- update Air/UI behavior for folder rendering and web setup interactions, with added unit, integration, and node test coverage

## Testing
- make ci-full

## Related docs
- https://cli.nylas.com/docs/commands/air
- https://cli.nylas.com/docs/commands/auth-config
- https://cli.nylas.com/docs/commands/init