### PR TITLE
TW-4939: Improve command discovery and diagnostic output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,17 +120,27 @@ test-air-integration:
 # Integration tests (requires NYLAS_API_KEY and NYLAS_GRANT_ID env vars)
 # Uses 10 minute timeout to prevent hanging on slow LLM calls
 # Output saved to test-integration.txt
+# Set NYLAS_TEST_SKIP_AGENT=true to skip TestCLI_Agent* when those already ran
 # NYLAS_DISABLE_KEYRING=true prevents keychain popup and skips tests that need local grant store
 # Rate limiting: 1 RPS with burst of 3 to stay well under Nylas API limits
 # -p 1: Run test packages sequentially to prevent rate limit issues
 test-integration:
 	@go clean -testcache
 	@bash -o pipefail -c '\
-		NYLAS_DISABLE_KEYRING=true \
-		NYLAS_TEST_RATE_LIMIT_RPS=$(NYLAS_TEST_RATE_LIMIT_RPS) \
-		NYLAS_TEST_RATE_LIMIT_BURST=$(NYLAS_TEST_RATE_LIMIT_BURST) \
-		NYLAS_TEST_BINARY=$(CURDIR)/bin/nylas \
-		go test ./... -tags=integration -v -timeout 10m -p 1 2>&1 | tee test-integration.txt \
+		skip_agent=$$(printf "%s" "$${NYLAS_TEST_SKIP_AGENT:-}" | tr "[:upper:]" "[:lower:]"); \
+		if [ "$$skip_agent" = "1" ] || [ "$$skip_agent" = "true" ]; then \
+			NYLAS_DISABLE_KEYRING=true \
+			NYLAS_TEST_RATE_LIMIT_RPS=$(NYLAS_TEST_RATE_LIMIT_RPS) \
+			NYLAS_TEST_RATE_LIMIT_BURST=$(NYLAS_TEST_RATE_LIMIT_BURST) \
+			NYLAS_TEST_BINARY=$(CURDIR)/bin/nylas \
+			go test -tags=integration -v -timeout 10m -p 1 -skip TestCLI_Agent ./... 2>&1 | tee test-integration.txt; \
+		else \
+			NYLAS_DISABLE_KEYRING=true \
+			NYLAS_TEST_RATE_LIMIT_RPS=$(NYLAS_TEST_RATE_LIMIT_RPS) \
+			NYLAS_TEST_RATE_LIMIT_BURST=$(NYLAS_TEST_RATE_LIMIT_BURST) \
+			NYLAS_TEST_BINARY=$(CURDIR)/bin/nylas \
+			go test -tags=integration -v -timeout 10m -p 1 ./... 2>&1 | tee test-integration.txt; \
+		fi \
 	'
 
 # Integration tests excluding slow LLM-dependent tests (for when Ollama is slow/unavailable)
@@ -338,6 +348,18 @@ ci-full:
 	@: > ci-full.txt
 	@bash -o pipefail -c '\
 		set -eu; \
+		cleanup_needed=0; \
+		run_cleanup() { \
+			if [ "$$cleanup_needed" -eq 1 ]; then \
+				echo ""; \
+				echo "================================="; \
+				echo "Cleaning up test resources..."; \
+				echo "================================="; \
+				$(MAKE) --no-print-directory test-cleanup || true; \
+				cleanup_needed=0; \
+			fi; \
+		}; \
+		trap '"'"'status=$$?; run_cleanup; trap - EXIT; exit $$status'"'"' EXIT; \
 		exec > >(tee -a ci-full.txt) 2>&1; \
 		$(MAKE) --no-print-directory ci; \
 		echo ""; \
@@ -349,18 +371,18 @@ ci-full:
 		echo "================================="; \
 		echo "Running Agent Integration Checks..."; \
 		echo "================================="; \
+		: "$${NYLAS_API_KEY:?NYLAS_API_KEY is required for agent integration tests}"; \
+		: "$${NYLAS_GRANT_ID:?NYLAS_GRANT_ID is required for agent integration tests}"; \
+		: "$${NYLAS_AGENT_DOMAIN:?NYLAS_AGENT_DOMAIN is required for agent integration tests}"; \
+		cleanup_needed=1; \
 		$(MAKE) --no-print-directory test-integration-agent; \
 		echo ""; \
 		echo "================================="; \
 		echo "Running Integration Tests..."; \
 		echo "================================="; \
-		$(MAKE) --no-print-directory test-integration; \
+		NYLAS_TEST_SKIP_AGENT=true $(MAKE) --no-print-directory test-integration; \
 		$(MAKE) --no-print-directory test-air-integration; \
-		echo ""; \
-		echo "================================="; \
-		echo "Cleaning up test resources..."; \
-		echo "================================="; \
-		$(MAKE) --no-print-directory test-cleanup; \
+		run_cleanup; \
 		echo ""; \
 		echo "================================="; \
 		echo "✓ Full CI pipeline completed!"; \

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/nylas/cli/internal/ports"
+)
+
+type commandFlagSpec struct {
+	Name      string `json:"name" yaml:"name"`
+	Shorthand string `json:"shorthand,omitempty" yaml:"shorthand,omitempty"`
+	Type      string `json:"type,omitempty" yaml:"type,omitempty"`
+	Default   string `json:"default,omitempty" yaml:"default,omitempty"`
+	Usage     string `json:"usage,omitempty" yaml:"usage,omitempty"`
+	Required  bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Hidden    bool   `json:"hidden,omitempty" yaml:"hidden,omitempty"`
+}
+
+type commandSpec struct {
+	Name           string            `json:"name" yaml:"name"`
+	Path           string            `json:"path" yaml:"path"`
+	Use            string            `json:"use" yaml:"use"`
+	Short          string            `json:"short,omitempty" yaml:"short,omitempty"`
+	Long           string            `json:"long,omitempty" yaml:"long,omitempty"`
+	Example        string            `json:"example,omitempty" yaml:"example,omitempty"`
+	Aliases        []string          `json:"aliases,omitempty" yaml:"aliases,omitempty"`
+	Deprecated     string            `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Hidden         bool              `json:"hidden,omitempty" yaml:"hidden,omitempty"`
+	Runnable       bool              `json:"runnable" yaml:"runnable"`
+	HasSubcommands bool              `json:"has_subcommands" yaml:"has_subcommands"`
+	Flags          []commandFlagSpec `json:"flags,omitempty" yaml:"flags,omitempty"`
+	InheritedFlags []commandFlagSpec `json:"inherited_flags,omitempty" yaml:"inherited_flags,omitempty"`
+	Subcommands    []commandSpec     `json:"subcommands,omitempty" yaml:"subcommands,omitempty"`
+}
+
+type commandRow struct {
+	Path    string
+	Short   string
+	Aliases string
+}
+
+func (r commandRow) QuietField() string {
+	return r.Path
+}
+
+func newCommandsCmd() *cobra.Command {
+	var includeHidden bool
+
+	cmd := &cobra.Command{
+		Use:   "commands [command-path...]",
+		Short: "Inspect command metadata",
+		Long: `Show machine-readable command and flag metadata for the CLI.
+
+By default, this prints a flat list of commands for quick browsing.
+Use --json or --format yaml to inspect a structured schema that agents and
+automation can consume without scraping prose help output.`,
+		Example: `  nylas commands
+  nylas commands --json
+  nylas commands email send --json
+  nylas commands --all --format yaml`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, err := resolveCommandTarget(cmd.Root(), args)
+			if err != nil {
+				return err
+			}
+
+			spec := buildCommandSpec(target, includeHidden)
+			if spec == nil {
+				return nil
+			}
+
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if quiet {
+				rows := flattenCommandSpec(*spec)
+				return common.GetOutputWriter(cmd).WriteList(rows, []ports.Column{
+					{Header: "Command", Field: "Path", Width: -1},
+				})
+			}
+
+			if common.IsStructuredOutput(cmd) {
+				return common.GetOutputWriter(cmd).Write(spec)
+			}
+
+			rows := flattenCommandSpec(*spec)
+			if target == cmd.Root() && len(rows) > 0 {
+				rows = rows[1:]
+			}
+			return common.GetOutputWriter(cmd).WriteList(rows, []ports.Column{
+				{Header: "Command", Field: "Path", Width: -1},
+				{Header: "Summary", Field: "Short", Width: -1},
+				{Header: "Aliases", Field: "Aliases", Width: -1},
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&includeHidden, "all", false, "Include hidden commands and flags")
+
+	return cmd
+}
+
+func resolveCommandTarget(root *cobra.Command, args []string) (*cobra.Command, error) {
+	if len(args) == 0 {
+		return root, nil
+	}
+
+	target, _, err := root.Find(args)
+	if err != nil {
+		return nil, err
+	}
+	if target == nil {
+		return nil, fmt.Errorf("command not found: %s", strings.Join(args, " "))
+	}
+
+	return target, nil
+}
+
+func buildCommandSpec(cmd *cobra.Command, includeHidden bool) *commandSpec {
+	if cmd == nil {
+		return nil
+	}
+	if cmd.Hidden && !includeHidden {
+		return nil
+	}
+
+	spec := &commandSpec{
+		Name:           cmd.Name(),
+		Path:           cmd.CommandPath(),
+		Use:            cmd.Use,
+		Short:          cmd.Short,
+		Long:           cmd.Long,
+		Example:        cmd.Example,
+		Aliases:        append([]string(nil), cmd.Aliases...),
+		Deprecated:     cmd.Deprecated,
+		Hidden:         cmd.Hidden,
+		Runnable:       cmd.Runnable(),
+		HasSubcommands: cmd.HasAvailableSubCommands(),
+	}
+
+	localFlags, localNames := collectCommandFlagSpecs(cmd, includeHidden)
+	spec.Flags = localFlags
+	spec.InheritedFlags = collectInheritedCommandFlagSpecs(cmd, includeHidden, localNames)
+
+	children := append([]*cobra.Command(nil), cmd.Commands()...)
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].Name() < children[j].Name()
+	})
+
+	for _, child := range children {
+		childSpec := buildCommandSpec(child, includeHidden)
+		if childSpec == nil {
+			continue
+		}
+		spec.Subcommands = append(spec.Subcommands, *childSpec)
+	}
+
+	return spec
+}
+
+func collectFlagSpecs(flags *pflag.FlagSet, includeHidden bool) []commandFlagSpec {
+	if flags == nil {
+		return nil
+	}
+
+	var specs []commandFlagSpec
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden && !includeHidden {
+			return
+		}
+
+		specs = append(specs, commandFlagSpec{
+			Name:      flag.Name,
+			Shorthand: flag.Shorthand,
+			Type:      flag.Value.Type(),
+			Default:   flag.DefValue,
+			Usage:     flag.Usage,
+			Required:  isRequiredFlag(flag),
+			Hidden:    flag.Hidden,
+		})
+	})
+
+	return specs
+}
+
+func collectCommandFlagSpecs(cmd *cobra.Command, includeHidden bool) ([]commandFlagSpec, map[string]struct{}) {
+	specs := make([]commandFlagSpec, 0)
+	names := make(map[string]struct{})
+
+	appendFlags := func(flags *pflag.FlagSet) {
+		for _, spec := range collectFlagSpecs(flags, includeHidden) {
+			if _, exists := names[spec.Name]; exists {
+				continue
+			}
+			names[spec.Name] = struct{}{}
+			specs = append(specs, spec)
+		}
+	}
+
+	appendFlags(cmd.Flags())
+	appendFlags(cmd.PersistentFlags())
+
+	sort.Slice(specs, func(i, j int) bool {
+		return specs[i].Name < specs[j].Name
+	})
+
+	return specs, names
+}
+
+func collectInheritedCommandFlagSpecs(cmd *cobra.Command, includeHidden bool, localNames map[string]struct{}) []commandFlagSpec {
+	specs := make([]commandFlagSpec, 0)
+	seen := make(map[string]struct{})
+
+	for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
+		for _, spec := range collectFlagSpecs(parent.PersistentFlags(), includeHidden) {
+			if _, exists := localNames[spec.Name]; exists {
+				continue
+			}
+			if _, exists := seen[spec.Name]; exists {
+				continue
+			}
+			seen[spec.Name] = struct{}{}
+			specs = append(specs, spec)
+		}
+	}
+
+	sort.Slice(specs, func(i, j int) bool {
+		return specs[i].Name < specs[j].Name
+	})
+
+	return specs
+}
+
+func isRequiredFlag(flag *pflag.Flag) bool {
+	if flag == nil || flag.Annotations == nil {
+		return false
+	}
+	_, ok := flag.Annotations[cobra.BashCompOneRequiredFlag]
+	return ok
+}
+
+func flattenCommandSpec(spec commandSpec) []commandRow {
+	rows := []commandRow{{
+		Path:    spec.Path,
+		Short:   spec.Short,
+		Aliases: strings.Join(spec.Aliases, ", "),
+	}}
+
+	for _, child := range spec.Subcommands {
+		rows = append(rows, flattenCommandSpec(child)...)
+	}
+
+	return rows
+}

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newCommandFixtureRoot() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "nylas",
+		Short: "Test root",
+	}
+	root.PersistentFlags().Bool("json", false, "Output as JSON")
+	root.PersistentFlags().String("format", "", "Output format")
+	root.PersistentFlags().BoolP("quiet", "q", false, "Quiet output")
+
+	sample := &cobra.Command{
+		Use:     "sample",
+		Short:   "Sample command",
+		Aliases: []string{"sm"},
+	}
+	sample.Flags().String("token", "", "Sample token")
+	_ = sample.MarkFlagRequired("token")
+
+	leaf := &cobra.Command{
+		Use:   "leaf",
+		Short: "Leaf command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	leaf.Flags().Bool("dry-run", false, "Preview the operation")
+
+	sample.AddCommand(leaf)
+	root.AddCommand(sample)
+	root.AddCommand(newCommandsCmd())
+
+	return root
+}
+
+func TestCommandsCmd_JSONRoot(t *testing.T) {
+	root := newCommandFixtureRoot()
+
+	stdout, stderr, err := executeCommand(root, "commands", "--json")
+	if err != nil {
+		t.Fatalf("commands --json failed: %v\nstderr: %s", err, stderr)
+	}
+
+	var spec commandSpec
+	if err := json.Unmarshal([]byte(stdout), &spec); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, stdout)
+	}
+
+	if spec.Name != "nylas" {
+		t.Fatalf("root name = %q, want nylas", spec.Name)
+	}
+
+	foundCommands := false
+	for _, sub := range spec.Subcommands {
+		if sub.Name == "commands" {
+			foundCommands = true
+			break
+		}
+	}
+	if !foundCommands {
+		t.Fatalf("expected commands command in root schema, got %+v", spec.Subcommands)
+	}
+}
+
+func TestCommandsCmd_JSONSubtreeIncludesFlags(t *testing.T) {
+	root := newCommandFixtureRoot()
+
+	stdout, stderr, err := executeCommand(root, "commands", "sample", "--json")
+	if err != nil {
+		t.Fatalf("commands sample --json failed: %v\nstderr: %s", err, stderr)
+	}
+
+	var spec commandSpec
+	if err := json.Unmarshal([]byte(stdout), &spec); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, stdout)
+	}
+
+	if spec.Path != "nylas sample" {
+		t.Fatalf("path = %q, want %q", spec.Path, "nylas sample")
+	}
+
+	hasRequiredToken := false
+	for _, flag := range spec.Flags {
+		if flag.Name == "token" && flag.Required {
+			hasRequiredToken = true
+			break
+		}
+	}
+	if !hasRequiredToken {
+		t.Fatalf("expected required token flag in %+v", spec.Flags)
+	}
+
+	hasInheritedJSON := false
+	for _, flag := range spec.InheritedFlags {
+		if flag.Name == "json" {
+			hasInheritedJSON = true
+			break
+		}
+	}
+	if !hasInheritedJSON {
+		t.Fatalf("expected inherited json flag in %+v", spec.InheritedFlags)
+	}
+
+	if len(spec.Subcommands) != 1 || spec.Subcommands[0].Name != "leaf" {
+		t.Fatalf("unexpected subcommands: %+v", spec.Subcommands)
+	}
+}
+
+func TestCommandsCmd_DefaultListOutput(t *testing.T) {
+	root := newCommandFixtureRoot()
+
+	stdout, stderr, err := executeCommand(root, "commands")
+	if err != nil {
+		t.Fatalf("commands failed: %v\nstderr: %s", err, stderr)
+	}
+
+	if strings.Contains(stdout, "nylas\n") {
+		t.Fatalf("default list output should not include the root row, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "nylas sample") {
+		t.Fatalf("expected sample command in output, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "nylas sample leaf") {
+		t.Fatalf("expected nested leaf command in output, got: %s", stdout)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -26,6 +27,44 @@ type CheckResult struct {
 	Detail  string
 }
 
+type doctorCheck struct {
+	spinnerMessage string
+	run            func() CheckResult
+}
+
+type doctorEnvironment struct {
+	Platform  string `json:"platform,omitempty" yaml:"platform,omitempty"`
+	GoVersion string `json:"go_version,omitempty" yaml:"go_version,omitempty"`
+	ConfigDir string `json:"config_dir,omitempty" yaml:"config_dir,omitempty"`
+}
+
+type doctorCheckOutput struct {
+	Name    string `json:"name" yaml:"name"`
+	Status  string `json:"status" yaml:"status"`
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	Detail  string `json:"detail,omitempty" yaml:"detail,omitempty"`
+}
+
+type doctorSummary struct {
+	OK            int    `json:"ok" yaml:"ok"`
+	Warning       int    `json:"warning" yaml:"warning"`
+	Error         int    `json:"error" yaml:"error"`
+	Skipped       int    `json:"skipped" yaml:"skipped"`
+	Total         int    `json:"total" yaml:"total"`
+	OverallStatus string `json:"overall_status" yaml:"overall_status"`
+}
+
+type doctorReport struct {
+	Environment     *doctorEnvironment  `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Checks          []doctorCheckOutput `json:"checks" yaml:"checks"`
+	Summary         doctorSummary       `json:"summary" yaml:"summary"`
+	Recommendations []string            `json:"recommendations,omitempty" yaml:"recommendations,omitempty"`
+}
+
+func (r doctorReport) QuietField() string {
+	return r.Summary.OverallStatus
+}
+
 // CheckStatus represents the status of a check.
 type CheckStatus int
 
@@ -35,6 +74,44 @@ const (
 	CheckStatusError
 	CheckStatusSkipped
 )
+
+var doctorChecks = []doctorCheck{
+	{
+		spinnerMessage: "Checking configuration...",
+		run:            checkConfig,
+	},
+	{
+		spinnerMessage: "Checking secret store...",
+		run:            checkSecretStore,
+	},
+	{
+		spinnerMessage: "Checking API credentials...",
+		run:            checkAPICredentials,
+	},
+	{
+		spinnerMessage: "Checking network connectivity...",
+		run:            checkNetworkConnectivity,
+	},
+	{
+		spinnerMessage: "Checking grants...",
+		run:            checkGrants,
+	},
+}
+
+func (s CheckStatus) String() string {
+	switch s {
+	case CheckStatusOK:
+		return "ok"
+	case CheckStatusWarning:
+		return "warning"
+	case CheckStatusError:
+		return "error"
+	case CheckStatusSkipped:
+		return "skipped"
+	default:
+		return "unknown"
+	}
+}
 
 func newDoctorCmd() *cobra.Command {
 	var verbose bool
@@ -55,7 +132,7 @@ Examples:
   nylas doctor
   nylas doctor --verbose`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDoctor(verbose)
+			return runDoctor(cmd, verbose)
 		},
 	}
 
@@ -64,107 +141,184 @@ Examples:
 	return cmd
 }
 
-func runDoctor(verbose bool) error {
-	_, _ = common.Bold.Println("Nylas CLI Health Check")
-	fmt.Println()
+func runDoctor(cmd *cobra.Command, verbose bool) error {
+	if isDoctorStructuredOutput(cmd) {
+		results := runDoctorChecks(false, nil)
+		if err := common.GetOutputWriter(cmd).Write(buildDoctorReport(results, verbose)); err != nil {
+			return err
+		}
+		return doctorResultsError(results)
+	}
 
-	results := []CheckResult{}
+	w := cmd.OutOrStdout()
+	_, _ = common.Bold.Fprintln(w, "Nylas CLI Health Check")
+	_, _ = fmt.Fprintln(w)
 
 	// Show environment info
 	if verbose {
-		_, _ = common.Dim.Printf("  Platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-		_, _ = common.Dim.Printf("  Go Version: %s\n", runtime.Version())
-		_, _ = common.Dim.Printf("  Config Dir: %s\n", config.DefaultConfigDir())
-		fmt.Println()
+		env := currentDoctorEnvironment()
+		_, _ = common.Dim.Fprintf(w, "  Platform: %s\n", env.Platform)
+		_, _ = common.Dim.Fprintf(w, "  Go Version: %s\n", env.GoVersion)
+		_, _ = common.Dim.Fprintf(w, "  Config Dir: %s\n", env.ConfigDir)
+		_, _ = fmt.Fprintln(w)
 	}
 
-	// 1. Check configuration file
-	configResult, _ := common.RunWithSpinnerResult("Checking configuration...", func() (CheckResult, error) {
-		return checkConfig(), nil
+	results := runDoctorChecks(true, func(result CheckResult) {
+		printCheckResult(w, result, verbose)
 	})
-	results = append(results, configResult)
-	printCheckResult(configResult, verbose)
-
-	// 2. Check secret store
-	secretResult, _ := common.RunWithSpinnerResult("Checking secret store...", func() (CheckResult, error) {
-		return checkSecretStore(), nil
-	})
-	results = append(results, secretResult)
-	printCheckResult(secretResult, verbose)
-
-	// 3. Check API credentials
-	apiKeyResult, _ := common.RunWithSpinnerResult("Checking API credentials...", func() (CheckResult, error) {
-		return checkAPICredentials(), nil
-	})
-	results = append(results, apiKeyResult)
-	printCheckResult(apiKeyResult, verbose)
-
-	// 4. Check network connectivity
-	networkResult, _ := common.RunWithSpinnerResult("Checking network connectivity...", func() (CheckResult, error) {
-		return checkNetworkConnectivity(), nil
-	})
-	results = append(results, networkResult)
-	printCheckResult(networkResult, verbose)
-
-	// 5. Check grants
-	grantsResult, _ := common.RunWithSpinnerResult("Checking grants...", func() (CheckResult, error) {
-		return checkGrants(), nil
-	})
-	results = append(results, grantsResult)
-	printCheckResult(grantsResult, verbose)
 
 	// Summary
-	fmt.Println()
-	_, _ = common.Bold.Println("Summary")
-	fmt.Println()
+	_, _ = fmt.Fprintln(w)
+	_, _ = common.Bold.Fprintln(w, "Summary")
+	_, _ = fmt.Fprintln(w)
 
-	okCount := 0
-	warnCount := 0
-	errCount := 0
+	summary := summarizeDoctorResults(results)
+	recommendations := doctorRecommendations(results)
 
-	for _, r := range results {
-		switch r.Status {
-		case CheckStatusOK:
-			okCount++
-		case CheckStatusWarning:
-			warnCount++
-		case CheckStatusError:
-			errCount++
+	if summary.Error > 0 {
+		_, _ = common.Red.Fprintf(w, "  %d error(s), %d warning(s), %d passed\n", summary.Error, summary.Warning, summary.OK)
+		_, _ = fmt.Fprintln(w)
+		_, _ = common.Cyan.Fprintln(w, "  Recommendations:")
+		for _, recommendation := range recommendations {
+			_, _ = fmt.Fprintf(w, "    - %s\n", recommendation)
 		}
-	}
-
-	if errCount > 0 {
-		_, _ = common.Red.Printf("  %d error(s), %d warning(s), %d passed\n", errCount, warnCount, okCount)
-		fmt.Println()
-		_, _ = common.Cyan.Println("  Recommendations:")
-		for _, r := range results {
-			if r.Status == CheckStatusError && r.Detail != "" {
-				fmt.Printf("    - %s\n", r.Detail)
-			}
-		}
-	} else if warnCount > 0 {
-		_, _ = common.Yellow.Printf("  %d warning(s), %d passed\n", warnCount, okCount)
-		fmt.Println()
-		_, _ = common.Cyan.Println("  Recommendations:")
-		for _, r := range results {
-			if r.Status == CheckStatusWarning && r.Detail != "" {
-				fmt.Printf("    - %s\n", r.Detail)
-			}
+	} else if summary.Warning > 0 {
+		_, _ = common.Yellow.Fprintf(w, "  %d warning(s), %d passed\n", summary.Warning, summary.OK)
+		_, _ = fmt.Fprintln(w)
+		_, _ = common.Cyan.Fprintln(w, "  Recommendations:")
+		for _, recommendation := range recommendations {
+			_, _ = fmt.Fprintf(w, "    - %s\n", recommendation)
 		}
 	} else {
-		_, _ = common.Green.Printf("  All %d checks passed!\n", okCount)
+		_, _ = common.Green.Fprintf(w, "  All %d checks passed!\n", summary.OK)
 	}
 
-	fmt.Println()
+	_, _ = fmt.Fprintln(w)
 
-	if errCount > 0 {
-		return fmt.Errorf("%d health check(s) failed", errCount)
+	return doctorResultsError(results)
+}
+
+func isDoctorStructuredOutput(cmd *cobra.Command) bool {
+	return common.IsStructuredOutput(cmd)
+}
+
+func currentDoctorEnvironment() doctorEnvironment {
+	return doctorEnvironment{
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		GoVersion: runtime.Version(),
+		ConfigDir: config.DefaultConfigDir(),
+	}
+}
+
+func runDoctorChecks(useSpinner bool, onResult func(CheckResult)) []CheckResult {
+	results := make([]CheckResult, 0, len(doctorChecks))
+
+	for _, check := range doctorChecks {
+		result := runDoctorCheck(check, useSpinner)
+		results = append(results, result)
+
+		if onResult != nil {
+			onResult(result)
+		}
 	}
 
+	return results
+}
+
+func runDoctorCheck(check doctorCheck, useSpinner bool) CheckResult {
+	if !useSpinner {
+		return check.run()
+	}
+
+	result, _ := common.RunWithSpinnerResult(check.spinnerMessage, func() (CheckResult, error) {
+		return check.run(), nil
+	})
+
+	return result
+}
+
+func buildDoctorReport(results []CheckResult, verbose bool) doctorReport {
+	checks := make([]doctorCheckOutput, 0, len(results))
+	for _, result := range results {
+		checks = append(checks, doctorCheckOutput{
+			Name:    result.Name,
+			Status:  result.Status.String(),
+			Message: result.Message,
+			Detail:  result.Detail,
+		})
+	}
+
+	report := doctorReport{
+		Checks:          checks,
+		Summary:         summarizeDoctorResults(results),
+		Recommendations: doctorRecommendations(results),
+	}
+
+	if verbose {
+		env := currentDoctorEnvironment()
+		report.Environment = &env
+	}
+
+	return report
+}
+
+func summarizeDoctorResults(results []CheckResult) doctorSummary {
+	summary := doctorSummary{
+		Total: len(results),
+	}
+
+	for _, result := range results {
+		switch result.Status {
+		case CheckStatusOK:
+			summary.OK++
+		case CheckStatusWarning:
+			summary.Warning++
+		case CheckStatusError:
+			summary.Error++
+		case CheckStatusSkipped:
+			summary.Skipped++
+		}
+	}
+
+	switch {
+	case summary.Error > 0:
+		summary.OverallStatus = CheckStatusError.String()
+	case summary.Warning > 0:
+		summary.OverallStatus = CheckStatusWarning.String()
+	case summary.OK > 0:
+		summary.OverallStatus = CheckStatusOK.String()
+	default:
+		summary.OverallStatus = CheckStatusSkipped.String()
+	}
+
+	return summary
+}
+
+func doctorRecommendations(results []CheckResult) []string {
+	targetStatus := CheckStatusWarning
+	if summarizeDoctorResults(results).Error > 0 {
+		targetStatus = CheckStatusError
+	}
+
+	recommendations := make([]string, 0)
+	for _, result := range results {
+		if result.Status == targetStatus && result.Detail != "" {
+			recommendations = append(recommendations, result.Detail)
+		}
+	}
+
+	return recommendations
+}
+
+func doctorResultsError(results []CheckResult) error {
+	summary := summarizeDoctorResults(results)
+	if summary.Error > 0 {
+		return fmt.Errorf("%d health check(s) failed", summary.Error)
+	}
 	return nil
 }
 
-func printCheckResult(r CheckResult, verbose bool) {
+func printCheckResult(w io.Writer, r CheckResult, verbose bool) {
 	var icon string
 	var colorFn *color.Color
 
@@ -183,14 +337,14 @@ func printCheckResult(r CheckResult, verbose bool) {
 		colorFn = common.Dim
 	}
 
-	_, _ = colorFn.Printf("  %s %s", icon, r.Name)
+	_, _ = colorFn.Fprintf(w, "  %s %s", icon, r.Name)
 	if r.Message != "" {
-		_, _ = common.Dim.Printf(" - %s", r.Message)
+		_, _ = common.Dim.Fprintf(w, " - %s", r.Message)
 	}
-	fmt.Println()
+	_, _ = fmt.Fprintln(w)
 
 	if verbose && r.Detail != "" {
-		_, _ = common.Dim.Printf("    %s\n", r.Detail)
+		_, _ = common.Dim.Fprintf(w, "    %s\n", r.Detail)
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,9 +1,16 @@
 package cli
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/nylas/cli/internal/cli/common"
+	"github.com/nylas/cli/internal/cli/testutil"
 )
 
 func TestCheckSecretStore_WarnsWhenFileStoreIsForced(t *testing.T) {
@@ -27,5 +34,176 @@ func TestCheckSecretStore_WarnsWhenFileStoreIsForced(t *testing.T) {
 	}
 	if !strings.Contains(result.Detail, "unset NYLAS_DISABLE_KEYRING") {
 		t.Fatalf("Detail %q does not mention unsetting NYLAS_DISABLE_KEYRING", result.Detail)
+	}
+}
+
+func TestDoctorCommandStructuredJSONUsesInheritedFlags(t *testing.T) {
+	restore := swapDoctorChecksForTest(t, []doctorCheck{
+		{
+			spinnerMessage: "Checking configuration...",
+			run: func() CheckResult {
+				return CheckResult{Name: "Configuration", Status: CheckStatusOK, Message: "ready"}
+			},
+		},
+		{
+			spinnerMessage: "Checking network...",
+			run: func() CheckResult {
+				return CheckResult{
+					Name:    "Network",
+					Status:  CheckStatusWarning,
+					Message: "slow",
+					Detail:  "High latency detected.",
+				}
+			},
+		},
+	})
+	defer restore()
+
+	root := newDoctorTestRoot()
+	stdout, stderr, err := testutil.ExecuteCommand(root, "doctor", "--json")
+	if err != nil {
+		t.Fatalf("doctor --json returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("doctor --json wrote stderr = %q, want empty", stderr)
+	}
+	if strings.Contains(stdout, "Nylas CLI Health Check") || strings.Contains(stdout, "Summary") {
+		t.Fatalf("doctor --json output contained human-readable prose: %q", stdout)
+	}
+
+	var report doctorReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("doctor --json output is not valid JSON: %v\noutput: %s", err, stdout)
+	}
+
+	if len(report.Checks) != 2 {
+		t.Fatalf("len(report.Checks) = %d, want 2", len(report.Checks))
+	}
+	if report.Checks[0].Status != "ok" {
+		t.Fatalf("report.Checks[0].Status = %q, want %q", report.Checks[0].Status, "ok")
+	}
+	if report.Checks[1].Status != "warning" {
+		t.Fatalf("report.Checks[1].Status = %q, want %q", report.Checks[1].Status, "warning")
+	}
+	if report.Summary.Warning != 1 || report.Summary.OK != 1 || report.Summary.OverallStatus != "warning" {
+		t.Fatalf("unexpected summary: %+v", report.Summary)
+	}
+	if len(report.Recommendations) != 1 || report.Recommendations[0] != "High latency detected." {
+		t.Fatalf("unexpected recommendations: %#v", report.Recommendations)
+	}
+	if report.Environment != nil {
+		t.Fatalf("report.Environment = %+v, want nil without --verbose", report.Environment)
+	}
+}
+
+func TestDoctorCommandStructuredYAMLIncludesVerboseEnvironment(t *testing.T) {
+	restore := swapDoctorChecksForTest(t, []doctorCheck{
+		{
+			spinnerMessage: "Checking configuration...",
+			run: func() CheckResult {
+				return CheckResult{Name: "Configuration", Status: CheckStatusOK, Message: "ready"}
+			},
+		},
+	})
+	defer restore()
+
+	root := newDoctorTestRoot()
+	stdout, stderr, err := testutil.ExecuteCommand(root, "doctor", "--format", "yaml", "--verbose")
+	if err != nil {
+		t.Fatalf("doctor --format yaml --verbose returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("doctor --format yaml --verbose wrote stderr = %q, want empty", stderr)
+	}
+	if strings.Contains(stdout, "Nylas CLI Health Check") || strings.Contains(stdout, "Summary") {
+		t.Fatalf("doctor --format yaml output contained human-readable prose: %q", stdout)
+	}
+
+	var report doctorReport
+	if err := yaml.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("doctor --format yaml output is not valid YAML: %v\noutput: %s", err, stdout)
+	}
+
+	if report.Environment == nil {
+		t.Fatal("report.Environment = nil, want verbose environment data")
+	}
+	if report.Environment.Platform == "" || report.Environment.GoVersion == "" || report.Environment.ConfigDir == "" {
+		t.Fatalf("report.Environment = %+v, want populated fields", report.Environment)
+	}
+	if report.Summary.Total != 1 || report.Summary.OverallStatus != "ok" {
+		t.Fatalf("unexpected summary: %+v", report.Summary)
+	}
+}
+
+func TestDoctorCommandQuietOutputsOverallStatus(t *testing.T) {
+	restore := swapDoctorChecksForTest(t, []doctorCheck{
+		{
+			spinnerMessage: "Checking configuration...",
+			run: func() CheckResult {
+				return CheckResult{Name: "Configuration", Status: CheckStatusWarning, Message: "slow", Detail: "Check config"}
+			},
+		},
+	})
+	defer restore()
+
+	root := newDoctorTestRoot()
+	stdout, stderr, err := testutil.ExecuteCommand(root, "doctor", "--quiet")
+	if err != nil {
+		t.Fatalf("doctor --quiet returned error: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("doctor --quiet wrote stderr = %q, want empty", stderr)
+	}
+	if strings.TrimSpace(stdout) != "warning" {
+		t.Fatalf("doctor --quiet output = %q, want %q", strings.TrimSpace(stdout), "warning")
+	}
+}
+
+func TestDoctorCommandDefaultOutputRemainsHumanReadable(t *testing.T) {
+	restore := swapDoctorChecksForTest(t, []doctorCheck{
+		{
+			spinnerMessage: "Checking configuration...",
+			run: func() CheckResult {
+				return CheckResult{Name: "Configuration", Status: CheckStatusOK, Message: "ready"}
+			},
+		},
+	})
+	defer restore()
+
+	root := newDoctorTestRoot()
+	stdout, _, err := testutil.ExecuteCommand(root, "doctor")
+	if err != nil {
+		t.Fatalf("doctor returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "Nylas CLI Health Check") {
+		t.Fatalf("doctor output missing header: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Summary") {
+		t.Fatalf("doctor output missing summary: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Configuration") {
+		t.Fatalf("doctor output missing check name: %q", stdout)
+	}
+}
+
+func newDoctorTestRoot() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "test",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	common.AddOutputFlags(root)
+	root.AddCommand(newDoctorCmd())
+	return root
+}
+
+func swapDoctorChecksForTest(t *testing.T, checks []doctorCheck) func() {
+	t.Helper()
+
+	original := doctorChecks
+	doctorChecks = checks
+
+	return func() {
+		doctorChecks = original
 	}
 }

--- a/internal/cli/email/search.go
+++ b/internal/cli/email/search.go
@@ -16,6 +16,12 @@ type messagesClient interface {
 	GetMessagesWithCursor(ctx context.Context, grantID string, params *domain.MessageQueryParams) (*domain.MessageListResponse, error)
 }
 
+var withSearchClient = func(args []string, fn func(context.Context, messagesClient, string) (struct{}, error)) (struct{}, error) {
+	return common.WithClient(args, func(ctx context.Context, client ports.NylasClient, grantID string) (struct{}, error) {
+		return fn(ctx, client, grantID)
+	})
+}
+
 func newSearchCmd() *cobra.Command {
 	var (
 		limit         int
@@ -28,7 +34,6 @@ func newSearchCmd() *cobra.Command {
 		unread        bool
 		starred       bool
 		inFolder      string
-		jsonOutput    bool
 	)
 
 	cmd := &cobra.Command{
@@ -59,7 +64,7 @@ Examples:
 			query := args[0]
 			remainingArgs := args[1:]
 
-			_, err := common.WithClient(remainingArgs, func(ctx context.Context, client ports.NylasClient, grantID string) (struct{}, error) {
+			_, err := withSearchClient(remainingArgs, func(ctx context.Context, client messagesClient, grantID string) (struct{}, error) {
 				// maxItems >= 0 triggers auto-pagination; < 0 means single-page fetch
 				maxItems := -1
 				if limit > common.MaxAPILimit {
@@ -118,21 +123,7 @@ Examples:
 					return struct{}{}, common.WrapSearchError("messages", err)
 				}
 
-				if jsonOutput {
-					return struct{}{}, common.PrintJSON(messages)
-				}
-
-				if len(messages) == 0 {
-					common.PrintEmptyStateWithHint("messages", "try different search terms")
-					return struct{}{}, nil
-				}
-
-				fmt.Printf("Found %d messages:\n\n", len(messages))
-				for i, msg := range messages {
-					printMessageSummary(msg, i+1)
-				}
-
-				return struct{}{}, nil
+				return struct{}{}, writeSearchOutput(cmd, messages)
 			})
 			return err
 		},
@@ -148,7 +139,6 @@ Examples:
 	cmd.Flags().BoolVar(&unread, "unread", false, "Only unread messages")
 	cmd.Flags().BoolVar(&starred, "starred", false, "Only starred messages")
 	cmd.Flags().StringVar(&inFolder, "in", "", "Filter by folder (e.g., INBOX, SENT)")
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 
 	return cmd
 }
@@ -182,4 +172,22 @@ func fetchMessages(ctx context.Context, client messagesClient, grantID string, p
 // parseDate parses a date string in YYYY-MM-DD format using local timezone.
 func parseDate(s string) (time.Time, error) {
 	return time.ParseInLocation("2006-01-02", s, time.Local)
+}
+
+func writeSearchOutput(cmd *cobra.Command, messages []domain.Message) error {
+	if common.IsStructuredOutput(cmd) {
+		return common.GetOutputWriter(cmd).WriteList(messages, nil)
+	}
+
+	if len(messages) == 0 {
+		common.PrintEmptyStateWithHint("messages", "try different search terms")
+		return nil
+	}
+
+	fmt.Printf("Found %d messages:\n\n", len(messages))
+	for i, msg := range messages {
+		printMessageSummary(msg, i+1)
+	}
+
+	return nil
 }

--- a/internal/cli/email/search_test.go
+++ b/internal/cli/email/search_test.go
@@ -1,16 +1,23 @@
 package email
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"strconv"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nylas/cli/internal/cli/common"
+	clitestutil "github.com/nylas/cli/internal/cli/testutil"
 	"github.com/nylas/cli/internal/domain"
+	"github.com/spf13/cobra"
 )
 
 type stubMessagesClient struct {
@@ -124,4 +131,125 @@ func makeMessages(count int, prefix string) []domain.Message {
 		messages[i] = domain.Message{ID: prefix + "-" + strconv.Itoa(i)}
 	}
 	return messages
+}
+
+func TestWriteSearchOutput(t *testing.T) {
+	t.Run("json output uses shared writer", func(t *testing.T) {
+		cmd := newSearchOutputTestCommand()
+
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetArgs([]string{"--json"})
+		require.NoError(t, cmd.Execute())
+
+		messages := []domain.Message{{ID: "msg-1"}, {ID: "msg-2"}}
+		require.NoError(t, writeSearchOutput(cmd, messages))
+
+		var got []domain.Message
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+		assert.Len(t, got, 2)
+		assert.Equal(t, "msg-1", got[0].ID)
+	})
+
+	t.Run("yaml output uses shared writer", func(t *testing.T) {
+		cmd := newSearchOutputTestCommand()
+
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetArgs([]string{"--format", "yaml"})
+		require.NoError(t, cmd.Execute())
+
+		messages := []domain.Message{{ID: "msg-1"}}
+		require.NoError(t, writeSearchOutput(cmd, messages))
+
+		var got []domain.Message
+		require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &got))
+		assert.Len(t, got, 1)
+		assert.Equal(t, "msg-1", got[0].ID)
+	})
+
+	t.Run("quiet output emits ids only", func(t *testing.T) {
+		cmd := newSearchOutputTestCommand()
+
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetArgs([]string{"--quiet"})
+		require.NoError(t, cmd.Execute())
+
+		messages := []domain.Message{{ID: "msg-1"}, {ID: "msg-2"}}
+		require.NoError(t, writeSearchOutput(cmd, messages))
+
+		lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+		assert.Equal(t, []string{"msg-1", "msg-2"}, lines)
+	})
+
+	t.Run("default output remains human readable", func(t *testing.T) {
+		messages := []domain.Message{{ID: "msg-1", Subject: "Project update"}}
+		cmd := &cobra.Command{
+			Use:           "search",
+			SilenceErrors: true,
+			SilenceUsage:  true,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return writeSearchOutput(cmd, messages)
+			},
+		}
+		common.AddOutputFlags(cmd)
+
+		stdout, _, err := clitestutil.ExecuteCommand(cmd)
+		require.NoError(t, err)
+
+		output := stdout
+		assert.Contains(t, output, "Found 1 messages")
+		assert.Contains(t, output, "Project update")
+	})
+}
+
+func TestSearchCommandStructuredOutputUsesInheritedFlags(t *testing.T) {
+	original := withSearchClient
+	defer func() {
+		withSearchClient = original
+	}()
+
+	withSearchClient = func(args []string, fn func(context.Context, messagesClient, string) (struct{}, error)) (struct{}, error) {
+		client := &stubMessagesClient{
+			getMessagesWithParamsFunc: func(_ context.Context, grantID string, params *domain.MessageQueryParams) ([]domain.Message, error) {
+				assert.Equal(t, "grant-123", grantID)
+				assert.Equal(t, "project update", params.Subject)
+				return []domain.Message{{ID: "msg-1"}}, nil
+			},
+		}
+
+		return fn(context.Background(), client, "grant-123")
+	}
+
+	root := &cobra.Command{
+		Use:           "test",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	common.AddOutputFlags(root)
+	root.AddCommand(newSearchCmd())
+
+	stdout, stderr, err := clitestutil.ExecuteCommand(root, "search", "project update", "--json")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(stderr))
+	assert.NotContains(t, stdout, "Found 1 messages")
+
+	var messages []domain.Message
+	require.NoError(t, json.Unmarshal([]byte(stdout), &messages))
+	require.Len(t, messages, 1)
+	assert.Equal(t, "msg-1", messages[0].ID)
+}
+
+func newSearchOutputTestCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "search",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	common.AddOutputFlags(cmd)
+	return cmd
 }

--- a/internal/cli/integration/commands_test.go
+++ b/internal/cli/integration/commands_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type integrationCommandSpec struct {
+	Name           string                   `json:"name"`
+	Path           string                   `json:"path"`
+	Flags          []integrationFlagSpec    `json:"flags"`
+	InheritedFlags []integrationFlagSpec    `json:"inherited_flags"`
+	Subcommands    []integrationCommandSpec `json:"subcommands"`
+}
+
+type integrationFlagSpec struct {
+	Name string `json:"name"`
+}
+
+func TestCLI_CommandsJSONRoot(t *testing.T) {
+	if testBinary == "" {
+		t.Skip("CLI binary not found - run 'go build -o bin/nylas ./cmd/nylas' first")
+	}
+
+	stdout, stderr, err := runCLI("commands", "--json")
+	if err != nil {
+		t.Fatalf("commands --json failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	var spec integrationCommandSpec
+	if err := json.Unmarshal([]byte(stdout), &spec); err != nil {
+		t.Fatalf("failed to parse commands JSON: %v\noutput: %s", err, stdout)
+	}
+
+	if spec.Name != "nylas" {
+		t.Fatalf("root name = %q, want nylas", spec.Name)
+	}
+
+	required := map[string]bool{
+		"commands": false,
+		"email":    false,
+		"calendar": false,
+		"mcp":      false,
+	}
+	for _, sub := range spec.Subcommands {
+		if _, ok := required[sub.Name]; ok {
+			required[sub.Name] = true
+		}
+	}
+
+	for name, found := range required {
+		if !found {
+			t.Fatalf("expected subcommand %q in commands output, got %+v", name, spec.Subcommands)
+		}
+	}
+}
+
+func TestCLI_CommandsJSONSubtree(t *testing.T) {
+	if testBinary == "" {
+		t.Skip("CLI binary not found - run 'go build -o bin/nylas ./cmd/nylas' first")
+	}
+
+	stdout, stderr, err := runCLI("commands", "email", "send", "--json")
+	if err != nil {
+		t.Fatalf("commands email send --json failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	var spec integrationCommandSpec
+	if err := json.Unmarshal([]byte(stdout), &spec); err != nil {
+		t.Fatalf("failed to parse commands subtree JSON: %v\noutput: %s", err, stdout)
+	}
+
+	if spec.Path != "nylas email send" {
+		t.Fatalf("path = %q, want %q", spec.Path, "nylas email send")
+	}
+
+	hasToFlag := false
+	for _, flag := range spec.Flags {
+		if flag.Name == "to" {
+			hasToFlag = true
+			break
+		}
+	}
+	if !hasToFlag {
+		t.Fatalf("expected local --to flag in %+v", spec.Flags)
+	}
+
+	hasJSONFlag := false
+	for _, flag := range spec.Flags {
+		if flag.Name == "json" {
+			hasJSONFlag = true
+			break
+		}
+	}
+	for _, flag := range spec.InheritedFlags {
+		if flag.Name == "json" {
+			hasJSONFlag = true
+			break
+		}
+	}
+	if !hasJSONFlag {
+		t.Fatalf("expected --json flag in local or inherited flags: local=%+v inherited=%+v", spec.Flags, spec.InheritedFlags)
+	}
+
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatal("expected JSON output")
+	}
+}

--- a/internal/cli/integration/mcp_status_test.go
+++ b/internal/cli/integration/mcp_status_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type integrationMCPStatus struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+func TestCLI_MCPStatusJSON(t *testing.T) {
+	if testBinary == "" {
+		t.Skip("CLI binary not found - run 'go build -o bin/nylas ./cmd/nylas' first")
+	}
+
+	stdout, stderr, err := runCLI("mcp", "status", "--json")
+	if err != nil {
+		t.Fatalf("mcp status --json failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	var statuses []integrationMCPStatus
+	if err := json.Unmarshal([]byte(stdout), &statuses); err != nil {
+		t.Fatalf("failed to parse mcp status JSON: %v\noutput: %s", err, stdout)
+	}
+	if len(statuses) == 0 {
+		t.Fatalf("expected at least one assistant status, got empty output: %s", stdout)
+	}
+
+	for _, status := range statuses {
+		if status.ID == "" {
+			t.Fatalf("assistant status missing id: %+v", status)
+		}
+		if status.Name == "" {
+			t.Fatalf("assistant status missing name: %+v", status)
+		}
+		if status.Status == "" {
+			t.Fatalf("assistant status missing status: %+v", status)
+		}
+	}
+}

--- a/internal/cli/mcp/assistants.go
+++ b/internal/cli/mcp/assistants.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -121,25 +120,7 @@ func (a Assistant) IsConfigured() bool {
 		return false
 	}
 
-	// #nosec G304 -- configPath from GetConfigPath() returns validated assistant config paths
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return false
-	}
-
-	var config map[string]any
-	if err := json.Unmarshal(data, &config); err != nil {
-		return false
-	}
-
-	// Check if mcpServers.nylas exists
-	mcpServers, ok := config["mcpServers"].(map[string]any)
-	if !ok {
-		return false
-	}
-
-	_, hasNylas := mcpServers["nylas"]
-	return hasNylas
+	return inspectAssistantConfig(a, configPath).HasNylas
 }
 
 // GetAssistantByID returns an assistant by ID.

--- a/internal/cli/mcp/config_helpers.go
+++ b/internal/cli/mcp/config_helpers.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+const nylasServerName = "nylas"
+
+type assistantConfigState struct {
+	ConfigFileExists bool
+	HasNylas         bool
+	BinaryPath       string
+	SchemaKey        string
+}
+
+func (a Assistant) installServerConfigKey() string {
+	if a.ID == "vscode" {
+		return "servers"
+	}
+
+	return "mcpServers"
+}
+
+func (a Assistant) serverConfigKeys() []string {
+	keys := []string{a.installServerConfigKey()}
+	if a.ID == "vscode" {
+		keys = append(keys, "mcpServers")
+	}
+
+	return keys
+}
+
+func loadConfig(configPath string) (map[string]any, error) {
+	// #nosec G304 -- configPath is derived from validated assistant config paths
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	config := make(map[string]any)
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func loadConfigIfExists(configPath string) (map[string]any, error) {
+	config, err := loadConfig(configPath)
+	if err == nil {
+		return config, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return make(map[string]any), nil
+	}
+
+	return nil, err
+}
+
+func writeConfig(configPath string, config map[string]any) error {
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(configPath, data, 0600)
+}
+
+func inspectAssistantConfig(a Assistant, configPath string) assistantConfigState {
+	config, err := loadConfig(configPath)
+	if err != nil {
+		return assistantConfigState{}
+	}
+
+	state := assistantConfigState{ConfigFileExists: true}
+	server, schemaKey, ok := findAssistantServer(config, a, nylasServerName)
+	if !ok {
+		return state
+	}
+
+	state.HasNylas = true
+	state.SchemaKey = schemaKey
+	state.BinaryPath, _ = server["command"].(string)
+
+	return state
+}
+
+func findAssistantServer(config map[string]any, a Assistant, serverName string) (map[string]any, string, bool) {
+	for _, key := range a.serverConfigKeys() {
+		servers, ok := config[key].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		server, ok := servers[serverName].(map[string]any)
+		if ok {
+			return server, key, true
+		}
+	}
+
+	return nil, "", false
+}
+
+func setAssistantServer(config map[string]any, a Assistant, serverName string, serverConfig map[string]any) {
+	primaryKey := a.installServerConfigKey()
+	servers, ok := config[primaryKey].(map[string]any)
+	if !ok {
+		servers = make(map[string]any)
+	}
+
+	servers[serverName] = serverConfig
+	config[primaryKey] = servers
+
+	for _, key := range a.serverConfigKeys() {
+		if key == primaryKey {
+			continue
+		}
+		removeAssistantServerFromKey(config, key, serverName)
+	}
+}
+
+func removeAssistantServer(config map[string]any, a Assistant, serverName string) bool {
+	removed := false
+
+	for _, key := range a.serverConfigKeys() {
+		if removeAssistantServerFromKey(config, key, serverName) {
+			removed = true
+		}
+	}
+
+	return removed
+}
+
+func removeAssistantServerFromKey(config map[string]any, key, serverName string) bool {
+	servers, ok := config[key].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	if _, exists := servers[serverName]; !exists {
+		return false
+	}
+
+	delete(servers, serverName)
+	if len(servers) == 0 {
+		delete(config, key)
+		return true
+	}
+
+	config[key] = servers
+	return true
+}

--- a/internal/cli/mcp/install.go
+++ b/internal/cli/mcp/install.go
@@ -187,35 +187,18 @@ func installForAssistant(a Assistant, binaryPath string) error {
 	}
 
 	// Read existing config or create new
-	config := make(map[string]any)
-	// #nosec G304 -- configPath from Assistant.GetConfigPath() returns validated AI assistant config paths
-	if data, err := os.ReadFile(configPath); err == nil {
-		if err := json.Unmarshal(data, &config); err != nil {
-			return fmt.Errorf("parsing existing config: %w", err)
-		}
+	config, err := loadConfigIfExists(configPath)
+	if err != nil {
+		return fmt.Errorf("parsing existing config: %w", err)
 	}
 
-	// Get or create mcpServers section
-	mcpServers, ok := config["mcpServers"].(map[string]any)
-	if !ok {
-		mcpServers = make(map[string]any)
-	}
-
-	// Add nylas server config
-	mcpServers["nylas"] = map[string]any{
+	setAssistantServer(config, a, nylasServerName, map[string]any{
 		"command": binaryPath,
 		"args":    []string{"mcp", "serve"},
-	}
-
-	config["mcpServers"] = mcpServers
+	})
 
 	// Write config
-	data, err := json.MarshalIndent(config, "", "  ")
-	if err != nil {
-		return fmt.Errorf("encoding config: %w", err)
-	}
-
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
+	if err := writeConfig(configPath, config); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
 

--- a/internal/cli/mcp/status.go
+++ b/internal/cli/mcp/status.go
@@ -1,13 +1,30 @@
 package mcp
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/nylas/cli/internal/cli/common"
 	"github.com/spf13/cobra"
 )
+
+type assistantStatus struct {
+	Name             string `json:"name" yaml:"name"`
+	ID               string `json:"id" yaml:"id"`
+	Status           string `json:"status" yaml:"status"`
+	ConfigPath       string `json:"config_path,omitempty" yaml:"config_path,omitempty"`
+	ProjectConfig    bool   `json:"project_config" yaml:"project_config"`
+	Supported        bool   `json:"supported" yaml:"supported"`
+	Installed        bool   `json:"installed" yaml:"installed"`
+	ConfigFileExists bool   `json:"config_file_exists" yaml:"config_file_exists"`
+	Configured       bool   `json:"configured" yaml:"configured"`
+	BinaryPath       string `json:"binary_path,omitempty" yaml:"binary_path,omitempty"`
+	SchemaKey        string `json:"schema_key,omitempty" yaml:"schema_key,omitempty"`
+}
+
+func (s assistantStatus) QuietField() string {
+	return s.ID
+}
 
 func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -19,87 +36,98 @@ This command checks which AI assistants have Nylas MCP configured and
 displays the configuration path for each.`,
 		Example: `  nylas mcp status`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStatus()
+			return runStatus(cmd)
 		},
 	}
 
 	return cmd
 }
 
-func runStatus() error {
-	fmt.Println("MCP Installation Status:")
-	fmt.Println()
-
-	for _, a := range Assistants {
-		configPath := a.GetConfigPath()
-		if configPath == "" {
-			_, _ = common.HiBlack.Printf("  - %-16s  unsupported on this platform\n", a.Name)
-			continue
-		}
-
-		// Check if app is installed
-		if !a.IsProjectConfig() && !a.IsInstalled() {
-			_, _ = common.HiBlack.Printf("  - %-16s  application not installed\n", a.Name)
-			continue
-		}
-
-		// Check if config file exists
-		if !a.IsConfigured() {
-			_, _ = common.Yellow.Printf("  ○ %-16s  ", a.Name)
-			fmt.Printf("not configured  %s\n", configPath)
-			continue
-		}
-
-		// Check if nylas is in the config
-		hasNylas, binaryPath := checkNylasInConfig(configPath)
-		if !hasNylas {
-			_, _ = common.Yellow.Printf("  ○ %-16s  ", a.Name)
-			fmt.Printf("config exists, nylas not added  %s\n", configPath)
-			continue
-		}
-
-		_, _ = common.Green.Printf("  ✓ %-16s  ", a.Name)
-		fmt.Printf("configured  %s\n", configPath)
-		if binaryPath != "" {
-			_, _ = common.HiBlack.Printf("                       binary: %s\n", binaryPath)
-		}
+func runStatus(cmd *cobra.Command) error {
+	statuses := collectAssistantStatuses(Assistants)
+	if common.IsStructuredOutput(cmd) {
+		return common.GetOutputWriter(cmd).WriteList(statuses, nil)
 	}
 
-	fmt.Println()
-	fmt.Println("Legend:")
-	_, _ = common.Green.Print("  ✓")
-	fmt.Println(" Nylas MCP configured")
-	_, _ = common.Yellow.Print("  ○")
-	fmt.Println(" Available but not configured")
-	_, _ = common.HiBlack.Print("  -")
-	fmt.Println(" Not available")
-
+	renderHumanStatus(cmd.OutOrStdout(), statuses)
 	return nil
 }
 
-// checkNylasInConfig checks if nylas is configured in the MCP config file.
-func checkNylasInConfig(configPath string) (bool, string) {
-	// #nosec G304 -- configPath from Assistant.GetConfigPath() returns validated AI assistant config paths
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return false, ""
+func collectAssistantStatuses(assistants []Assistant) []assistantStatus {
+	statuses := make([]assistantStatus, 0, len(assistants))
+
+	for _, a := range assistants {
+		statuses = append(statuses, getAssistantStatus(a))
 	}
 
-	var config map[string]any
-	if err := json.Unmarshal(data, &config); err != nil {
-		return false, ""
+	return statuses
+}
+
+func getAssistantStatus(a Assistant) assistantStatus {
+	configPath := a.GetConfigPath()
+	status := assistantStatus{
+		Name:          a.Name,
+		ID:            a.ID,
+		Status:        "unsupported",
+		ConfigPath:    configPath,
+		ProjectConfig: a.IsProjectConfig(),
 	}
 
-	mcpServers, ok := config["mcpServers"].(map[string]any)
-	if !ok {
-		return false, ""
+	if configPath == "" {
+		return status
 	}
 
-	nylas, ok := mcpServers["nylas"].(map[string]any)
-	if !ok {
-		return false, ""
+	status.Supported = true
+	status.Installed = true
+
+	if !a.IsProjectConfig() && !a.IsInstalled() {
+		status.Status = "not_installed"
+		status.Installed = false
+		return status
 	}
 
-	binaryPath, _ := nylas["command"].(string)
-	return true, binaryPath
+	configState := inspectAssistantConfig(a, configPath)
+	status.ConfigFileExists = configState.ConfigFileExists
+	status.Configured = configState.HasNylas
+	status.BinaryPath = configState.BinaryPath
+	status.SchemaKey = configState.SchemaKey
+
+	if configState.HasNylas {
+		status.Status = "configured"
+		return status
+	}
+
+	status.Status = "not_configured"
+	return status
+}
+
+func renderHumanStatus(w io.Writer, statuses []assistantStatus) {
+	_, _ = fmt.Fprintln(w, "MCP Installation Status:")
+	_, _ = fmt.Fprintln(w)
+
+	for _, status := range statuses {
+		switch status.Status {
+		case "unsupported":
+			_, _ = fmt.Fprintf(w, "  - %-16s  unsupported on this platform\n", status.Name)
+		case "not_installed":
+			_, _ = fmt.Fprintf(w, "  - %-16s  application not installed\n", status.Name)
+		case "configured":
+			_, _ = fmt.Fprintf(w, "  ✓ %-16s  configured  %s\n", status.Name, status.ConfigPath)
+			if status.BinaryPath != "" {
+				_, _ = fmt.Fprintf(w, "                       binary: %s\n", status.BinaryPath)
+			}
+		default:
+			message := "not configured"
+			if status.ConfigFileExists {
+				message = "config exists, nylas not added"
+			}
+			_, _ = fmt.Fprintf(w, "  ○ %-16s  %s  %s\n", status.Name, message, status.ConfigPath)
+		}
+	}
+
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Legend:")
+	_, _ = fmt.Fprintln(w, "  ✓ Nylas MCP configured")
+	_, _ = fmt.Fprintln(w, "  ○ Available but not configured")
+	_, _ = fmt.Fprintln(w, "  - Not available")
 }

--- a/internal/cli/mcp/status_test.go
+++ b/internal/cli/mcp/status_test.go
@@ -1,0 +1,210 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nylas/cli/internal/cli/common"
+	clitestutil "github.com/nylas/cli/internal/cli/testutil"
+)
+
+func TestInstallForAssistantUsesAssistantSpecificSchema(t *testing.T) {
+	t.Run("vscode uses servers and removes legacy entry", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "mcp.json")
+		err := os.WriteFile(configPath, []byte(`{"mcpServers":{"nylas":{"command":"old","args":["mcp","serve"]}}}`), 0600)
+		if err != nil {
+			t.Fatalf("writing config: %v", err)
+		}
+
+		assistant := testAssistant("vscode", configPath)
+		if err := installForAssistant(assistant, "/usr/local/bin/nylas"); err != nil {
+			t.Fatalf("installForAssistant returned error: %v", err)
+		}
+
+		config := readMCPTestConfig(t, configPath)
+		servers := getConfigSection(t, config, "servers")
+		if _, ok := servers["nylas"]; !ok {
+			t.Fatalf("expected nylas server in servers section, got %+v", servers)
+		}
+		if _, ok := config["mcpServers"]; ok {
+			t.Fatalf("expected legacy mcpServers section to be removed, got %+v", config["mcpServers"])
+		}
+	})
+
+	t.Run("cursor uses mcpServers", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "mcp.json")
+		assistant := testAssistant("cursor", configPath)
+
+		if err := installForAssistant(assistant, "/usr/local/bin/nylas"); err != nil {
+			t.Fatalf("installForAssistant returned error: %v", err)
+		}
+
+		config := readMCPTestConfig(t, configPath)
+		mcpServers := getConfigSection(t, config, "mcpServers")
+		if _, ok := mcpServers["nylas"]; !ok {
+			t.Fatalf("expected nylas server in mcpServers section, got %+v", mcpServers)
+		}
+	})
+}
+
+func TestUninstallFromAssistantRemovesConfiguredServer(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "mcp.json")
+	err := os.WriteFile(configPath, []byte(`{
+  "servers":{"nylas":{"command":"new","args":["mcp","serve"]}},
+  "mcpServers":{"nylas":{"command":"old","args":["mcp","serve"]}}
+}`), 0600)
+	if err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	assistant := testAssistant("vscode", configPath)
+	if err := uninstallFromAssistant(assistant); err != nil {
+		t.Fatalf("uninstallFromAssistant returned error: %v", err)
+	}
+
+	config := readMCPTestConfig(t, configPath)
+	if _, ok := config["servers"]; ok {
+		t.Fatalf("expected servers section removed, got %+v", config["servers"])
+	}
+	if _, ok := config["mcpServers"]; ok {
+		t.Fatalf("expected mcpServers section removed, got %+v", config["mcpServers"])
+	}
+}
+
+func TestInspectAssistantConfigAcceptsLegacyVSCodeSchema(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "mcp.json")
+	err := os.WriteFile(configPath, []byte(`{"mcpServers":{"nylas":{"command":"legacy","args":["mcp","serve"]}}}`), 0600)
+	if err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	assistant := testAssistant("vscode", configPath)
+	state := inspectAssistantConfig(assistant, configPath)
+
+	if !state.ConfigFileExists || !state.HasNylas {
+		t.Fatalf("unexpected config state: %+v", state)
+	}
+	if state.SchemaKey != "mcpServers" {
+		t.Fatalf("state.SchemaKey = %q, want %q", state.SchemaKey, "mcpServers")
+	}
+	if state.BinaryPath != "legacy" {
+		t.Fatalf("state.BinaryPath = %q, want %q", state.BinaryPath, "legacy")
+	}
+}
+
+func TestStatusCommandStructuredOutput(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "mcp.json")
+	assistant := testAssistant("vscode", configPath)
+
+	config := map[string]any{}
+	setAssistantServer(config, assistant, nylasServerName, map[string]any{
+		"command": "/usr/local/bin/nylas",
+		"args":    []string{"mcp", "serve"},
+	})
+	if err := writeConfig(configPath, config); err != nil {
+		t.Fatalf("writeConfig returned error: %v", err)
+	}
+
+	restore := swapAssistantsForTest(t, []Assistant{assistant})
+	defer restore()
+
+	root := newMCPStatusTestRoot()
+	stdout, stderr, err := clitestutil.ExecuteCommand(root, "status", "--json")
+	if err != nil {
+		t.Fatalf("status --json returned error: %v\nstderr: %s", err, stderr)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("status --json wrote stderr = %q, want empty", stderr)
+	}
+	if strings.Contains(stdout, "MCP Installation Status") {
+		t.Fatalf("status --json output contained human-readable prose: %q", stdout)
+	}
+
+	var statuses []assistantStatus
+	if err := json.Unmarshal([]byte(stdout), &statuses); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, stdout)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("len(statuses) = %d, want 1", len(statuses))
+	}
+	if statuses[0].Status != "configured" {
+		t.Fatalf("statuses[0].Status = %q, want %q", statuses[0].Status, "configured")
+	}
+	if statuses[0].SchemaKey != "servers" {
+		t.Fatalf("statuses[0].SchemaKey = %q, want %q", statuses[0].SchemaKey, "servers")
+	}
+}
+
+func TestStatusCommandDefaultOutputRemainsHumanReadable(t *testing.T) {
+	restore := swapAssistantsForTest(t, []Assistant{testAssistant("cursor", filepath.Join(t.TempDir(), "cursor.json"))})
+	defer restore()
+
+	root := newMCPStatusTestRoot()
+	stdout, _, err := clitestutil.ExecuteCommand(root, "status")
+	if err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "MCP Installation Status") {
+		t.Fatalf("default output missing header: %q", stdout)
+	}
+	if !strings.Contains(stdout, "Not available") {
+		t.Fatalf("default output missing legend: %q", stdout)
+	}
+}
+
+func newMCPStatusTestRoot() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "test",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	common.AddOutputFlags(root)
+	root.AddCommand(newStatusCmd())
+	return root
+}
+
+func swapAssistantsForTest(t *testing.T, assistants []Assistant) func() {
+	t.Helper()
+
+	original := Assistants
+	Assistants = assistants
+
+	return func() {
+		Assistants = original
+	}
+}
+
+func testAssistant(id, configPath string) Assistant {
+	return Assistant{
+		Name:        "Test Assistant",
+		ID:          id,
+		ConfigPaths: map[string]string{runtime.GOOS: configPath},
+		AppPaths:    map[string]string{runtime.GOOS: ""},
+	}
+}
+
+func readMCPTestConfig(t *testing.T, configPath string) map[string]any {
+	t.Helper()
+
+	config, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatalf("loadConfig returned error: %v", err)
+	}
+	return config
+}
+
+func getConfigSection(t *testing.T, config map[string]any, key string) map[string]any {
+	t.Helper()
+
+	section, ok := config[key].(map[string]any)
+	if !ok {
+		t.Fatalf("expected %s section in %+v", key, config)
+	}
+	return section
+}

--- a/internal/cli/mcp/uninstall.go
+++ b/internal/cli/mcp/uninstall.go
@@ -1,9 +1,7 @@
 package mcp
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/nylas/cli/internal/cli/common"
 	"github.com/spf13/cobra"
@@ -61,19 +59,14 @@ func runUninstall(assistantID string, uninstallAll bool) error {
 			continue
 		}
 
-		// Check if config exists
-		if !a.IsConfigured() {
+		configState := inspectAssistantConfig(a, configPath)
+		if !configState.HasNylas {
 			if !uninstallAll {
-				_, _ = common.Yellow.Printf("  ! %s: not configured\n", a.Name)
-			}
-			continue
-		}
-
-		// Check if nylas is in the config
-		hasNylas, _ := checkNylasInConfig(configPath)
-		if !hasNylas {
-			if !uninstallAll {
-				_, _ = common.Yellow.Printf("  ! %s: nylas not found in config\n", a.Name)
+				msg := "not configured"
+				if configState.ConfigFileExists {
+					msg = "nylas not found in config"
+				}
+				_, _ = common.Yellow.Printf("  ! %s: %s\n", a.Name, msg)
 			}
 			continue
 		}
@@ -100,40 +93,15 @@ func uninstallFromAssistant(a Assistant) error {
 	configPath := a.GetConfigPath()
 
 	// Read existing config
-	// #nosec G304 -- configPath from Assistant.GetConfigPath() returns validated AI assistant config paths
-	data, err := os.ReadFile(configPath)
+	config, err := loadConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("reading config: %w", err)
 	}
 
-	var config map[string]any
-	if err := json.Unmarshal(data, &config); err != nil {
-		return fmt.Errorf("parsing config: %w", err)
-	}
-
-	// Get mcpServers section
-	mcpServers, ok := config["mcpServers"].(map[string]any)
-	if !ok {
-		return nil // No mcpServers section
-	}
-
-	// Remove nylas entry
-	delete(mcpServers, "nylas")
-
-	// If mcpServers is now empty, remove it entirely
-	if len(mcpServers) == 0 {
-		delete(config, "mcpServers")
-	} else {
-		config["mcpServers"] = mcpServers
-	}
+	removeAssistantServer(config, a, nylasServerName)
 
 	// Write config back
-	data, err = json.MarshalIndent(config, "", "  ")
-	if err != nil {
-		return fmt.Errorf("encoding config: %w", err)
-	}
-
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
+	if err := writeConfig(configPath, config); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,6 +19,7 @@ var rootCmd = &cobra.Command{
   nylas email list       List recent emails
   nylas calendar events  Upcoming events
   nylas contacts list    List contacts
+  nylas commands --json  Machine-readable command tree
 
 Documentation: https://cli.nylas.com/`,
 	SilenceUsage:  true,
@@ -96,6 +97,9 @@ func printWelcome() {
 	_, _ = common.Dim.Print("nylas --help")
 	fmt.Println("              All commands")
 	fmt.Print("  ")
+	_, _ = common.Dim.Print("nylas commands --json")
+	fmt.Println("     Machine-readable command tree")
+	fmt.Print("  ")
 	_, _ = common.Dim.Println("https://cli.nylas.com     Documentation")
 	fmt.Println()
 }
@@ -122,6 +126,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().String("config", "", "Custom config file path")
 
+	rootCmd.AddCommand(newCommandsCmd())
 	rootCmd.AddCommand(newVersionCmd())
 
 	// Initialize audit logging hooks


### PR DESCRIPTION
## Summary
- add a machine-readable `nylas commands` surface and refresh root help for agent-oriented command discovery
- improve `doctor` and `nylas mcp status` output for structured consumers, with shared MCP config inspection helpers and coverage
- harden email search pagination and `ci-full` orchestration so agent integration tests run once without broad cleanup or leaked skip flags

## Testing
- make ci-full