### PR TITLE
TW-4938: Fix Air cache test dirty release state

### DIFF
--- a/internal/air/cache/settings.go
+++ b/internal/air/cache/settings.go
@@ -239,6 +239,10 @@ func (s *Settings) BasePath() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	if s.filePath == "" {
+		return ""
+	}
+
 	return filepath.Dir(s.filePath)
 }
 

--- a/internal/air/cache/settings_test.go
+++ b/internal/air/cache/settings_test.go
@@ -40,6 +40,14 @@ func TestLoadSettings_NewFile(t *testing.T) {
 	}
 }
 
+func TestDefaultSettingsBasePathIsEmptyUntilLoaded(t *testing.T) {
+	settings := DefaultSettings()
+
+	if got := settings.BasePath(); got != "" {
+		t.Fatalf("DefaultSettings().BasePath() = %q, want empty path", got)
+	}
+}
+
 func TestLoadSettings_ExistingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/air/handlers_email_cache_runtime_test.go
+++ b/internal/air/handlers_email_cache_runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -83,7 +84,10 @@ func newCachedTestServer(t *testing.T) (*Server, *nylasmock.MockClient, string) 
 		t.Fatalf("new cache manager: %v", err)
 	}
 
-	settings := cache.DefaultSettings()
+	settings, err := cache.LoadSettings(tmpDir)
+	if err != nil {
+		t.Fatalf("load cache settings: %v", err)
+	}
 	settings.Enabled = true
 	settings.OfflineQueueEnabled = true
 
@@ -113,6 +117,15 @@ func newCachedTestServer(t *testing.T) (*Server, *nylasmock.MockClient, string) 
 	})
 
 	return server, client, email
+}
+
+func TestNewCachedTestServerSettingsUseTempCachePath(t *testing.T) {
+	server, _, accountEmail := newCachedTestServer(t)
+
+	want := filepath.Dir(server.cacheManager.DBPath(accountEmail))
+	if got := server.cacheSettings.BasePath(); got != want {
+		t.Fatalf("cache settings base path = %q, want cache manager base path %q", got, want)
+	}
 }
 
 func putCachedEmail(t *testing.T, server *Server, accountEmail string, email *cache.CachedEmail) {


### PR DESCRIPTION
## Summary
- Prevent unbacked Air cache settings from resolving their base path to the package working directory.
- Keep Air cache-runtime test settings on the same temp directory as the test SQLite manager.
- Add regressions covering the empty settings base path and the cache test helper path.

## Test Plan
- `go test ./... -short`
- `git ls-files --others --exclude-standard internal/air`
