### PR TITLE
TW-4908: rename managed transactional to Agent Account in CLI docs and helpers

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -219,10 +219,10 @@ nylas email read <message-id> --decrypt                        # Decrypt encrypt
 nylas email read <message-id> --decrypt --verify               # Decrypt + verify signature
 ```
 
-**Managed send behavior:**
-- Grants with provider `nylas` use the managed transactional send path automatically.
-- The sender address comes from the active grant email for those managed accounts.
-- GPG signing/encryption and `--signature-id` are not supported for managed transactional sends.
+**Agent Account send behavior:**
+- Grants with provider `nylas` use per-grant send: `/v3/grants/{grant_id}/messages/send`.
+- The sender address comes from the active grant email when one is not supplied.
+- GPG signing/encryption and `--signature-id` are not supported for Agent Account sends in the CLI.
 
 **AI features:**
 ```bash

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -202,10 +202,11 @@ Agent accounts can also expose the mailbox over IMAP and SMTP submission when an
 ## Sending Email from Agent Accounts
 
 When the active grant is an agent account (`provider=nylas`):
-- `nylas email send` automatically uses the managed transactional send path
-- the sender address is taken from the active grant email
-- GPG signing/encryption is not supported on that managed transactional path
-- stored signatures via `--signature-id` are not supported on that managed transactional path
+- `nylas email send` uses per-grant send: `/v3/grants/{grant_id}/messages/send`
+- the sender address is taken from the active grant email when one is not supplied
+- Agent Account sends do not use the domain transactional relay endpoint
+- GPG signing/encryption is not supported for Agent Account sends in the CLI
+- stored signatures via `--signature-id` are not supported for Agent Account sends in the CLI
 
 ## See Also
 

--- a/docs/commands/email.md
+++ b/docs/commands/email.md
@@ -130,10 +130,11 @@ nylas email send --to "to@example.com" --subject "Hello" --body "Body" --yes
 - `--signature-id` - Append a stored signature when sending, creating a draft, or sending a draft
 
 **Managed provider (`nylas`):**
-- `nylas email send` uses the managed transactional send path automatically
-- the sender address is taken from the active grant email
-- `--signature-id` is not supported for managed transactional sends
-- `--sign` and `--encrypt` are not supported for managed transactional sends
+- `nylas email send` uses per-grant send: `/v3/grants/{grant_id}/messages/send`
+- the sender address is taken from the active grant email when one is not supplied
+- Agent Account sends do not use the domain transactional relay endpoint
+- `--signature-id` is not supported for Agent Account sends in the CLI
+- `--sign` and `--encrypt` are not supported for Agent Account sends in the CLI
 
 **Example output (scheduled):**
 ```bash
@@ -198,7 +199,7 @@ nylas email send --list-gpg-keys
 
 `--signature-id` can't be combined with `--sign` or `--encrypt`, because stored signatures are only supported on the standard JSON send and draft endpoints.
 
-Managed transactional sends from `provider=nylas` also do not support `--sign`, `--encrypt`, or `--signature-id`.
+Agent Account sends from `provider=nylas` use per-grant send and do not support `--sign`, `--encrypt`, or `--signature-id` in the CLI.
 
 ### Signatures
 

--- a/internal/adapters/nylas/transactional.go
+++ b/internal/adapters/nylas/transactional.go
@@ -23,7 +23,7 @@ func buildTransactionalSendPayload(req *domain.SendMessageRequest) map[string]an
 }
 
 // SendTransactionalMessage sends an email via the domain-based transactional endpoint.
-// Used for managed Nylas grants: POST /v3/domains/{domain}/messages/send
+// POST /v3/domains/{domain}/messages/send
 func (c *HTTPClient) SendTransactionalMessage(ctx context.Context, domainName string, req *domain.SendMessageRequest) (*domain.Message, error) {
 	queryURL := fmt.Sprintf("%s/v3/domains/%s/messages/send", c.baseURL, url.PathEscape(domainName))
 

--- a/internal/cli/email/send_helpers.go
+++ b/internal/cli/email/send_helpers.go
@@ -30,7 +30,7 @@ func sendMessageForGrant(
 	grant *domain.Grant,
 	req *domain.SendMessageRequest,
 ) (*domain.Message, error) {
-	if isManagedTransactionalGrant(grant) && len(req.From) == 0 && grant.Email != "" {
+	if isNylasProviderGrant(grant) && len(req.From) == 0 && grant.Email != "" {
 		req.From = []domain.EmailParticipant{{Email: grant.Email}}
 	}
 	return client.SendMessage(ctx, grantID, req)

--- a/internal/cli/email/signatures_support.go
+++ b/internal/cli/email/signatures_support.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nylas/cli/internal/ports"
 )
 
-func isManagedTransactionalGrant(grant *domain.Grant) bool {
+func isNylasProviderGrant(grant *domain.Grant) bool {
 	return grant != nil && grant.Provider == domain.ProviderNylas
 }
 
@@ -24,10 +24,10 @@ func validateSendSignatureSupport(signatureID string, sign, encrypt bool, grant 
 			"Use standard JSON send mode without --sign/--encrypt, or add the signature HTML directly to the message body",
 		)
 	}
-	if isManagedTransactionalGrant(grant) {
+	if isNylasProviderGrant(grant) {
 		return common.NewUserError(
-			"`--signature-id` is not supported for managed transactional sends",
-			"Managed Nylas grants use the domain-based transactional send endpoint, which does not accept signature_id",
+			"`--signature-id` is not supported for Agent Account sends",
+			"Agent Account sends use per-grant message send; add the signature HTML directly to the message body",
 		)
 	}
 	return nil
@@ -37,12 +37,12 @@ func validateManagedSecureSendSupport(sign, encrypt bool, grant *domain.Grant) e
 	if !sign && !encrypt {
 		return nil
 	}
-	if !isManagedTransactionalGrant(grant) {
+	if !isNylasProviderGrant(grant) {
 		return nil
 	}
 	return common.NewUserError(
-		"`--sign` and `--encrypt` are not supported for managed transactional sends",
-		"Managed Nylas grants use the domain-based transactional send endpoint, which does not support raw MIME GPG send",
+		"`--sign` and `--encrypt` are not supported for Agent Account sends",
+		"Agent Account sends use per-grant JSON message send in the CLI; raw MIME GPG send is not supported for provider=nylas grants",
 	)
 }
 

--- a/internal/cli/email/signatures_test.go
+++ b/internal/cli/email/signatures_test.go
@@ -135,7 +135,7 @@ func TestValidateSignatureSelection(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Nil(t, signatures)
-		assert.ErrorContains(t, err, "`--signature-id` is not supported for managed transactional sends")
+		assert.ErrorContains(t, err, "`--signature-id` is not supported for Agent Account sends")
 		assert.False(t, mock.GetGrantCalled)
 		assert.False(t, mock.GetSignaturesCalled)
 	})

--- a/internal/ports/transactional.go
+++ b/internal/ports/transactional.go
@@ -7,9 +7,10 @@ import (
 )
 
 // TransactionalClient defines the interface for domain-based transactional email operations.
-// This is used for managed Nylas grants which use domain-based endpoints instead of grant-based.
+// Normal Agent Account mailbox sends use per-grant message send so they can
+// preserve mailbox behavior such as Sent-folder archiving.
 type TransactionalClient interface {
 	// SendTransactionalMessage sends an email via the domain-based transactional endpoint.
-	// Used for managed Nylas grants: POST /v3/domains/{domain}/messages/send
+	// POST /v3/domains/{domain}/messages/send
 	SendTransactionalMessage(ctx context.Context, domainName string, req *domain.SendMessageRequest) (*domain.Message, error)
 }


### PR DESCRIPTION
## Summary
- Follow-up to TW-4880 (which routed `provider=nylas` grants through per-grant send): replaces "managed transactional" copy with "Agent Account" across user-facing docs and error messages.
- Renames internal helper `isManagedTransactionalGrant` → `isNylasProviderGrant` and updates its callers/tests.
- Clarifies that Agent Account sends use `/v3/grants/{grant_id}/messages/send`, not the domain transactional relay; GPG (`--sign`/`--encrypt`) and `--signature-id` remain unsupported on that path in the CLI.

## Test plan
- [x] `go fmt ./...` / `go vet ./...`
- [x] `make test-unit` (covers `signatures_test.go` updated assertion)
- [ ] Spot-check `nylas email send` against an Agent Account grant — error copy now reads "Agent Account sends"
- [ ] Spot-check `nylas email send --signature-id ...` against an Agent Account grant — surfaces the new error message

## Related command docs
- https://cli.nylas.com/docs/commands/email-send
- https://cli.nylas.com/docs/commands/email-signatures-create
- https://cli.nylas.com/docs/commands/agent-account-list
- https://cli.nylas.com/docs/commands/agent-status

JIRA: [TW-4908](https://nylas.atlassian.net/browse/TW-4908) (Epic: [TW-4638](https://nylas.atlassian.net/browse/TW-4638))

[TW-4908]: https://nylas.atlassian.net/browse/TW-4908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ