### PR TITLE
TW-4910: TUI scope mismatch — structured errors, flash safety, q-to-quit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nylas/cli
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/atotto/clipboard v0.1.4

--- a/internal/cli/common/errors.go
+++ b/internal/cli/common/errors.go
@@ -3,6 +3,7 @@ package common
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/fatih/color"
@@ -48,6 +49,43 @@ func WrapError(err error) *CLIError {
 	var cliErr *CLIError
 	if errors.As(err, &cliErr) {
 		return cliErr
+	}
+
+	// Only match structured insufficient_scopes; generic 401/403 falls through.
+	var apiErr *domain.APIError
+	if errors.As(err, &apiErr) {
+		if strings.EqualFold(strings.TrimSpace(apiErr.Type), "insufficient_scopes") {
+			msg := strings.TrimSpace(apiErr.Message)
+			if msg == "" {
+				msg = "Grant lacks required scopes for this operation"
+			}
+			return &CLIError{
+				Err:     err,
+				Message: msg,
+				Suggestions: []string{
+					"Run 'nylas auth show' to inspect the grant's current scopes",
+					"Run 'nylas auth login' to re-authorize the grant with the required scopes",
+					"Or 'nylas auth switch <grant-id-or-email>' to use a different grant",
+				},
+				Code: ErrCodePermissionDenied,
+			}
+		}
+		switch {
+		case apiErr.StatusCode == http.StatusTooManyRequests:
+			return &CLIError{
+				Err:        err,
+				Message:    "Rate limit exceeded",
+				Suggestion: "Wait a moment and try again, or reduce the frequency of requests",
+				Code:       ErrCodeRateLimited,
+			}
+		case apiErr.StatusCode >= http.StatusInternalServerError:
+			return &CLIError{
+				Err:        err,
+				Message:    "Nylas API server error",
+				Suggestion: "This is a temporary issue. Please try again in a few minutes",
+				Code:       ErrCodeServerError,
+			}
+		}
 	}
 
 	// Map domain errors to CLI errors

--- a/internal/cli/common/errors_test.go
+++ b/internal/cli/common/errors_test.go
@@ -111,6 +111,94 @@ func TestWrapError_DomainErrors_Extended(t *testing.T) {
 	}
 }
 
+func TestWrapError_InsufficientScopes(t *testing.T) {
+	t.Run("with message", func(t *testing.T) {
+		apiErr := &domain.APIError{
+			StatusCode: 403,
+			Type:       "insufficient_scopes",
+			Message:    "Grant lacks required scope: gmail.readonly",
+		}
+		wrapped := fmt.Errorf("failed to fetch threads: %w", apiErr)
+
+		result := WrapError(wrapped)
+
+		require.NotNil(t, result)
+		assert.Equal(t, ErrCodePermissionDenied, result.Code)
+		assert.Equal(t, "Grant lacks required scope: gmail.readonly", result.Message)
+		if assert.NotEmpty(t, result.Suggestions) {
+			joined := strings.Join(result.Suggestions, " | ")
+			assert.Contains(t, joined, "nylas auth show")
+			assert.Contains(t, joined, "nylas auth login")
+		}
+	})
+
+	t.Run("empty message", func(t *testing.T) {
+		apiErr := &domain.APIError{
+			StatusCode: 403,
+			Type:       "insufficient_scopes",
+		}
+		result := WrapError(apiErr)
+
+		require.NotNil(t, result)
+		assert.Equal(t, ErrCodePermissionDenied, result.Code)
+		assert.Equal(t, "Grant lacks required scopes for this operation", result.Message)
+		if assert.NotEmpty(t, result.Suggestions) {
+			joined := strings.Join(result.Suggestions, " | ")
+			assert.Contains(t, joined, "nylas auth show")
+		}
+	})
+}
+
+func TestWrapError_GenericForbiddenFallsThrough(t *testing.T) {
+	// 403 without insufficient_scopes type should fall through to default
+	// wrapper, not get the scope-specific suggestion.
+	apiErr := &domain.APIError{StatusCode: 403, Message: "Access denied"}
+	result := WrapError(apiErr)
+
+	require.NotNil(t, result)
+	assert.NotEqual(t, ErrCodePermissionDenied, result.Code, "generic 403 should not be classified as scope error")
+	for _, s := range result.Suggestions {
+		assert.NotContains(t, s, "auth show", "generic 403 should not get scope-specific suggestion")
+	}
+}
+
+func TestWrapError_APIErrorStatusClassification(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         *domain.APIError
+		wantMessage string
+		wantCode    string
+		wantSuggest string
+	}{
+		{
+			name:        "type only rate limit",
+			err:         &domain.APIError{StatusCode: 429, Type: "api_error"},
+			wantMessage: "Rate limit exceeded",
+			wantCode:    ErrCodeRateLimited,
+			wantSuggest: "reduce the frequency",
+		},
+		{
+			name:        "type only server error",
+			err:         &domain.APIError{StatusCode: 500, Type: "api_error"},
+			wantMessage: "Nylas API server error",
+			wantCode:    ErrCodeServerError,
+			wantSuggest: "temporary issue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WrapError(tt.err)
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantMessage, result.Message)
+			assert.Equal(t, tt.wantCode, result.Code)
+			assert.Contains(t, result.Suggestion, tt.wantSuggest)
+			assert.True(t, errors.Is(result, domain.ErrAPIError))
+		})
+	}
+}
+
 func TestWrapError_SecretStorePassphraseRequirement(t *testing.T) {
 	err := fmt.Errorf("%w: %s must be set to unlock the encrypted file store", domain.ErrSecretStoreFailed, "NYLAS_FILE_STORE_PASSPHRASE")
 

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -39,7 +39,7 @@ Navigation:
   :           Command mode
   /           Filter
   ?           Help
-  Ctrl+C      Quit
+  q, Ctrl+C   Quit
 
 Themes:
   k9s         Default k9s style (blue/orange)

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -95,10 +95,15 @@ func (e *APIError) Error() string {
 	}
 
 	message := strings.TrimSpace(e.Message)
-	if message != "" {
+	errType := strings.TrimSpace(e.Type)
+	switch {
+	case message != "" && errType != "":
+		return fmt.Sprintf("%s: %s (%s)", ErrAPIError, message, errType)
+	case message != "":
 		return fmt.Sprintf("%s: %s", ErrAPIError, message)
-	}
-	if e.StatusCode > 0 {
+	case errType != "":
+		return fmt.Sprintf("%s: %s", ErrAPIError, errType)
+	case e.StatusCode > 0:
 		return fmt.Sprintf("%s: status %d", ErrAPIError, e.StatusCode)
 	}
 	return ErrAPIError.Error()

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *APIError
+		want    []string
+		wantNot []string
+	}{
+		{
+			name: "message and type both surfaced",
+			err:  &APIError{StatusCode: 403, Type: "insufficient_scopes", Message: "Grant lacks gmail.readonly"},
+			want: []string{"Grant lacks gmail.readonly", "insufficient_scopes"},
+		},
+		{
+			name: "message only",
+			err:  &APIError{StatusCode: 403, Message: "Access denied"},
+			want: []string{"Access denied"},
+		},
+		{
+			name:    "type only (empty message)",
+			err:     &APIError{StatusCode: 403, Type: "insufficient_scopes"},
+			want:    []string{"insufficient_scopes"},
+			wantNot: []string{"status 403"},
+		},
+		{
+			name: "neither message nor type",
+			err:  &APIError{StatusCode: 403},
+			want: []string{"status 403"},
+		},
+		{
+			name: "completely empty",
+			err:  &APIError{},
+			want: []string{ErrAPIError.Error()},
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: []string{ErrAPIError.Error()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("Error() = %q, missing substring %q", got, want)
+				}
+			}
+			for _, notWant := range tt.wantNot {
+				if strings.Contains(got, notWant) {
+					t.Errorf("Error() = %q, should not contain %q", got, notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestAPIError_UnwrapsToErrAPIError(t *testing.T) {
+	err := &APIError{StatusCode: 403, Type: "insufficient_scopes"}
+	if !errors.Is(err, ErrAPIError) {
+		t.Errorf("APIError should unwrap to ErrAPIError")
+	}
+}

--- a/internal/tui/app_init.go
+++ b/internal/tui/app_init.go
@@ -128,6 +128,13 @@ func (a *App) setupKeys() {
 
 		case tcell.KeyRune:
 			switch event.Rune() {
+			case 'q', 'Q':
+				// Quit the application (k9s/less/top convention).
+				// Suppressed in compose/forms via the inDetailView branch above
+				// and in command/filter mode via the early returns above.
+				a.Stop()
+				return nil
+
 			case ':':
 				// Enter command mode with palette (autocomplete)
 				a.showPalette()

--- a/internal/tui/app_keys_test.go
+++ b/internal/tui/app_keys_test.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestAppQKeyQuitsStopsApplication(t *testing.T) {
+	tests := []struct {
+		name string
+		r    rune
+	}{
+		{"lowercase q", 'q'},
+		{"uppercase Q", 'Q'},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := createTestApp(t)
+			capture := app.GetInputCapture()
+			if capture == nil {
+				t.Fatal("expected app input capture to be set")
+			}
+
+			app.mx.Lock()
+			app.running = true
+			app.mx.Unlock()
+
+			event := tcell.NewEventKey(tcell.KeyRune, tt.r, tcell.ModNone)
+			result := capture(event)
+			if result != nil {
+				t.Errorf("expected %q to be consumed (return nil), got %v", tt.r, result)
+			}
+
+			app.mx.RLock()
+			running := app.running
+			app.mx.RUnlock()
+			if running {
+				t.Errorf("expected %q to stop the app", tt.r)
+			}
+		})
+	}
+}

--- a/internal/tui/availability_base.go
+++ b/internal/tui/availability_base.go
@@ -145,7 +145,7 @@ func (v *AvailabilityView) loadCalendars() {
 
 	calendars, err := v.app.config.Client.GetCalendars(ctx, v.app.config.GrantID)
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load calendars: %v", err)
+		v.app.FlashLoadError("Failed to load calendars", err)
 		return
 	}
 

--- a/internal/tui/drafts.go
+++ b/internal/tui/drafts.go
@@ -54,7 +54,7 @@ func (v *DraftsView) Load() {
 
 	drafts, err := v.app.config.Client.GetDrafts(ctx, v.app.config.GrantID, 50)
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load drafts: %v", err)
+		v.app.FlashLoadError("Failed to load drafts", err)
 		return
 	}
 	v.drafts = drafts

--- a/internal/tui/flash_helpers.go
+++ b/internal/tui/flash_helpers.go
@@ -1,0 +1,16 @@
+package tui
+
+import "fmt"
+
+// FlashLoadError flashes an error from a Load() call in the status bar.
+// Safe to call from any goroutine, including from inside a QueueUpdateDraw
+// callback — the inner QueueUpdateDraw is dispatched in a new goroutine
+// so callers never block the event loop waiting on itself.
+func (a *App) FlashLoadError(fallback string, err error) {
+	msg := fmt.Sprintf("%s: %v", fallback, err)
+	go func() {
+		a.QueueUpdateDraw(func() {
+			a.status.Flash(FlashError, msg)
+		})
+	}()
+}

--- a/internal/tui/flash_helpers_test.go
+++ b/internal/tui/flash_helpers_test.go
@@ -1,0 +1,127 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/nylas/cli/internal/domain"
+)
+
+func TestFlashLoadErrorDoesNotDeadlockInsideQueuedUpdate(t *testing.T) {
+	app := createTestApp(t)
+	screen := tcell.NewSimulationScreen("")
+	screen.SetSize(80, 24)
+	app.SetScreen(screen)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- app.Run()
+	}()
+	t.Cleanup(func() {
+		app.Stop()
+		select {
+		case err := <-runErr:
+			if err != nil {
+				t.Errorf("app.Run() returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Log("app did not stop before cleanup timeout")
+		}
+	})
+
+	ready := make(chan struct{})
+	go func() {
+		app.QueueUpdateDraw(func() {
+			close(ready)
+		})
+	}()
+	select {
+	case <-ready:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for TUI event loop")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		app.QueueUpdateDraw(func() {
+			app.FlashLoadError("Failed to load drafts", errors.New("boom"))
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("FlashLoadError deadlocked when called during an existing queued update")
+	}
+}
+
+func TestFlashLoadErrorBeforeRunIsVisibleAfterStart(t *testing.T) {
+	app := createTestApp(t)
+	app.FlashLoadError("Failed to load threads", &domain.APIError{
+		StatusCode: 403,
+		Type:       "insufficient_scopes",
+		Message:    "Grant lacks gmail.readonly",
+	})
+
+	screen := tcell.NewSimulationScreen("")
+	screen.SetSize(80, 24)
+	app.SetScreen(screen)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- app.Run()
+	}()
+	t.Cleanup(func() {
+		app.Stop()
+		select {
+		case err := <-runErr:
+			if err != nil {
+				t.Errorf("app.Run() returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Log("app did not stop before cleanup timeout")
+		}
+	})
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("expected initial load error to be flashed")
+			return
+		case <-ticker.C:
+			text := readStatusText(t, app)
+			if strings.Contains(text, "Failed to load threads") &&
+				strings.Contains(text, "Grant lacks gmail.readonly") &&
+				strings.Contains(text, "insufficient_scopes") {
+				return
+			}
+		}
+	}
+}
+
+func readStatusText(t *testing.T, app *App) string {
+	t.Helper()
+
+	var statusText string
+	done := make(chan struct{})
+	go func() {
+		app.QueueUpdateDraw(func() {
+			statusText = app.status.GetText(true)
+			close(done)
+		})
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for status read")
+	}
+	return statusText
+}

--- a/internal/tui/folder_panel.go
+++ b/internal/tui/folder_panel.go
@@ -107,7 +107,7 @@ func (p *FolderPanel) Load() {
 
 	folders, err := p.app.config.Client.GetFolders(ctx, p.app.config.GrantID)
 	if err != nil {
-		p.app.Flash(FlashError, "Failed to load folders: %v", err)
+		p.app.FlashLoadError("Failed to load folders", err)
 		return
 	}
 

--- a/internal/tui/views_contacts.go
+++ b/internal/tui/views_contacts.go
@@ -45,7 +45,7 @@ func (v *ContactsView) Load() {
 	defer cancel()
 	contacts, err := v.app.config.Client.GetContacts(ctx, v.app.config.GrantID, nil)
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load contacts: %v", err)
+		v.app.FlashLoadError("Failed to load contacts", err)
 		return
 	}
 	v.contacts = contacts

--- a/internal/tui/views_dashboard.go
+++ b/internal/tui/views_dashboard.go
@@ -41,7 +41,7 @@ func (v *DashboardView) Hints() []Hint {
 	return []Hint{
 		{Key: ":", Desc: "command"},
 		{Key: "?", Desc: "help"},
-		{Key: "^C", Desc: "quit"},
+		{Key: "q", Desc: "quit"},
 	}
 }
 

--- a/internal/tui/views_events.go
+++ b/internal/tui/views_events.go
@@ -81,7 +81,7 @@ func (v *EventsView) Load() {
 	// Get calendars first
 	calendars, err := v.app.config.Client.GetCalendars(ctx, v.app.config.GrantID)
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load calendars: %v", err)
+		v.app.FlashLoadError("Failed to load calendars", err)
 		return
 	}
 
@@ -113,7 +113,7 @@ func (v *EventsView) loadEventsForCalendar(calendarID string) {
 		Limit:           200,
 	})
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load events: %v", err)
+		v.app.FlashLoadError("Failed to load events", err)
 		return
 	}
 

--- a/internal/tui/views_grants.go
+++ b/internal/tui/views_grants.go
@@ -47,7 +47,7 @@ func (v *GrantsView) Load() {
 	defer cancel()
 	grants, err := v.app.config.Client.ListGrants(ctx)
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load grants: %v", err)
+		v.app.FlashLoadError("Failed to load grants", err)
 		return
 	}
 	v.grants = grants

--- a/internal/tui/views_messages.go
+++ b/internal/tui/views_messages.go
@@ -108,7 +108,7 @@ func (v *MessagesView) Load() {
 	}
 	threads, err := v.app.config.Client.GetThreads(ctx, v.app.config.GrantID, params)
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load threads: %v", err)
+		v.app.FlashLoadError("Failed to load threads", err)
 		return
 	}
 	v.threads = threads

--- a/internal/tui/views_webhooks.go
+++ b/internal/tui/views_webhooks.go
@@ -47,7 +47,7 @@ func (v *WebhooksView) Load() {
 	defer cancel()
 	webhooks, err := v.app.config.Client.ListWebhooks(ctx)
 	if err != nil {
-		v.app.Flash(FlashError, "Failed to load webhooks: %v", err)
+		v.app.FlashLoadError("Failed to load webhooks", err)
 		return
 	}
 	v.webhooks = webhooks


### PR DESCRIPTION
## Summary
- Surface `insufficient_scopes` API errors with actionable suggestions (`nylas auth show`, `nylas auth login`, `nylas auth switch`) instead of generic error messages; falls back to human-readable text when the API message is empty
- Add goroutine-safe `FlashLoadError` helper to prevent data races when TUI views flash errors from background `Load()` goroutines
- Add `q`/`Q` to quit (k9s/less/top convention), guarded in filter mode, command palette, and detail views (compose/forms)
- Improve `APIError.Error()` to surface both message and type for better diagnostics
- Add structured 429 rate-limit and 5xx server error classification in `WrapError`

## Test plan
- [ ] `go test ./internal/domain/` — APIError.Error() all branches + Unwrap
- [ ] `go test ./internal/cli/common/` — insufficient_scopes with/empty message, generic 403 fallthrough, 429, 500
- [ ] `go test ./internal/tui/ -run TestFlash` — deadlock-freedom, pre-run flash visibility
- [ ] `go test ./internal/tui/ -run TestAppQKey` — q/Q stop behavior
- [ ] Manual: `nylas tui` → verify `q` quits, but not during `:` command mode, `/` filter, or compose forms

## Docs
- [nylas tui](https://cli.nylas.com/docs/commands/tui)