### PR TITLE
TW-4931: fix snakeToPascal to handle URL acronym in config keys

### DIFF
--- a/internal/cli/config/get.go
+++ b/internal/cli/config/get.go
@@ -99,6 +99,7 @@ func snakeToPascal(s string) string {
 		"ai":  "AI",
 		"gpg": "GPG",
 		"id":  "ID",
+		"url": "URL",
 	}
 
 	parts := strings.Split(s, "_")

--- a/internal/cli/config/get_test.go
+++ b/internal/cli/config/get_test.go
@@ -24,7 +24,7 @@ func TestSnakeToPascal(t *testing.T) {
 		{
 			name:  "snake_case three words",
 			input: "api_base_url",
-			want:  "APIBaseUrl",
+			want:  "APIBaseURL",
 		},
 		{
 			name:  "already camelCase",
@@ -62,7 +62,7 @@ func TestGetConfigValue(t *testing.T) {
 	// Test struct matching typical config structure
 	type APIConfig struct {
 		Timeout string
-		BaseUrl string
+		BaseURL string
 	}
 
 	type OutputConfig struct {
@@ -151,7 +151,7 @@ func TestGetConfigValue(t *testing.T) {
 			name: "deeply nested field",
 			cfg: &TestConfig{
 				API: &APIConfig{
-					BaseUrl: "https://api.us.nylas.com",
+					BaseURL: "https://api.us.nylas.com",
 				},
 			},
 			key:  "api.base_url",


### PR DESCRIPTION
## Summary
- `nylas config set api.base_url` failed with "unknown config key" because `snakeToPascal` converted `url` to `Url` instead of `URL`
- Added `"url": "URL"` to the acronyms map so snake_case config keys with `url` resolve correctly to struct fields

## Test plan
- [x] `nylas config set api.base_url <value>` works
- [x] `nylas config get api.base_url` round-trips correctly
- [x] `nylas config set dashboard.account_base_url <value>` works
- [x] Unit tests updated and passing