### PR TITLE
TW-4937: surface API request ID in CLI error output

### DIFF
--- a/internal/adapters/nylas/agent_test.go
+++ b/internal/adapters/nylas/agent_test.go
@@ -82,6 +82,52 @@ func TestParseError_FallsBackToStatusCodeWhenBodyEmpty(t *testing.T) {
 	assert.Empty(t, apiErr.Message)
 }
 
+func TestParseError_CapturesRequestIDFromBody(t *testing.T) {
+	client := NewHTTPClient()
+
+	resp := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     http.Header{},
+		Body: io.NopCloser(strings.NewReader(`{
+			"request_id": "1120765200-c4c8e151-3414-4448-b884-1498872b0912",
+			"error": {
+				"code": "token.unauthorized_access",
+				"type": "token.unauthorized_access",
+				"message": "Bearer token invalid"
+			}
+		}`)),
+	}
+
+	err := client.parseError(resp)
+	require.Error(t, err)
+
+	var apiErr *domain.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.Equal(t, "token.unauthorized_access", apiErr.Type)
+	assert.Equal(t, "Bearer token invalid", apiErr.Message)
+	assert.Equal(t, "1120765200-c4c8e151-3414-4448-b884-1498872b0912", apiErr.RequestID)
+	assert.Contains(t, err.Error(), "request_id: 1120765200-c4c8e151-3414-4448-b884-1498872b0912")
+}
+
+func TestParseError_FallsBackToRequestIDHeader(t *testing.T) {
+	client := NewHTTPClient()
+
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Header:     http.Header{"X-Request-Id": []string{"hdr-req-42"}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	err := client.parseError(resp)
+	require.Error(t, err)
+
+	var apiErr *domain.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "hdr-req-42", apiErr.RequestID)
+	assert.Contains(t, err.Error(), "request_id: hdr-req-42")
+}
+
 func TestListAgentAccounts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v3/grants", r.URL.Path)

--- a/internal/adapters/nylas/client.go
+++ b/internal/adapters/nylas/client.go
@@ -123,17 +123,21 @@ func (c *HTTPClient) setAuthHeader(req *http.Request) {
 // parseError parses an error response from the API.
 // Uses streaming decoder with size limit to avoid large allocations.
 func (c *HTTPClient) parseError(resp *http.Response) error {
+	requestID := getRequestID(resp)
+
 	// Limit error response body to 10KB to prevent memory issues
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024))
 	if err != nil || len(body) == 0 {
-		return &domain.APIError{StatusCode: resp.StatusCode}
+		return &domain.APIError{StatusCode: resp.StatusCode, RequestID: requestID}
 	}
 
 	// Try Nylas standard format: {"error": {"message": "...", "type": "..."}}
+	// with optional top-level "request_id" (present in some 4xx responses).
 	var errResp struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-		Error   struct {
+		Message   string `json:"message"`
+		Type      string `json:"type"`
+		RequestID string `json:"request_id"`
+		Error     struct {
 			Message string `json:"message"`
 			Type    string `json:"type"`
 		} `json:"error"`
@@ -147,11 +151,15 @@ func (c *HTTPClient) parseError(resp *http.Response) error {
 		if errType == "" {
 			errType = strings.TrimSpace(errResp.Type)
 		}
+		if bodyReqID := strings.TrimSpace(errResp.RequestID); bodyReqID != "" {
+			requestID = bodyReqID
+		}
 		if message != "" || errType != "" {
 			return &domain.APIError{
 				StatusCode: resp.StatusCode,
 				Type:       errType,
 				Message:    message,
+				RequestID:  requestID,
 			}
 		}
 	}
@@ -160,20 +168,25 @@ func (c *HTTPClient) parseError(resp *http.Response) error {
 	var oauthErr struct {
 		Error       string `json:"error"`
 		Description string `json:"error_description"`
+		RequestID   string `json:"request_id"`
 	}
 	if err := json.Unmarshal(body, &oauthErr); err == nil && oauthErr.Error != "" {
 		message := oauthErr.Description
 		if message == "" {
 			message = oauthErr.Error
 		}
+		if bodyReqID := strings.TrimSpace(oauthErr.RequestID); bodyReqID != "" {
+			requestID = bodyReqID
+		}
 		return &domain.APIError{
 			StatusCode: resp.StatusCode,
 			Type:       oauthErr.Error,
 			Message:    message,
+			RequestID:  requestID,
 		}
 	}
 
-	return &domain.APIError{StatusCode: resp.StatusCode}
+	return &domain.APIError{StatusCode: resp.StatusCode, RequestID: requestID}
 }
 
 // getRequestID extracts the request ID from response headers.

--- a/internal/cli/common/errors.go
+++ b/internal/cli/common/errors.go
@@ -17,6 +17,7 @@ type CLIError struct {
 	Suggestion  string   // Single suggestion (deprecated, use Suggestions)
 	Suggestions []string // Multiple suggestions
 	Code        string
+	RequestID   string
 }
 
 func (e *CLIError) Error() string {
@@ -67,7 +68,8 @@ func WrapError(err error) *CLIError {
 					"Run 'nylas auth login' to re-authorize the grant with the required scopes",
 					"Or 'nylas auth switch <grant-id-or-email>' to use a different grant",
 				},
-				Code: ErrCodePermissionDenied,
+				Code:      ErrCodePermissionDenied,
+				RequestID: apiErr.RequestID,
 			}
 		}
 		switch {
@@ -77,6 +79,7 @@ func WrapError(err error) *CLIError {
 				Message:    "Rate limit exceeded",
 				Suggestion: "Wait a moment and try again, or reduce the frequency of requests",
 				Code:       ErrCodeRateLimited,
+				RequestID:  apiErr.RequestID,
 			}
 		case apiErr.StatusCode >= http.StatusInternalServerError:
 			return &CLIError{
@@ -84,6 +87,7 @@ func WrapError(err error) *CLIError {
 				Message:    "Nylas API server error",
 				Suggestion: "This is a temporary issue. Please try again in a few minutes",
 				Code:       ErrCodeServerError,
+				RequestID:  apiErr.RequestID,
 			}
 		}
 	}
@@ -230,10 +234,19 @@ func WrapError(err error) *CLIError {
 		}
 	}
 
-	// Default wrapper
+	// Default wrapper — extract request ID from APIError if present,
+	// and strip the inline [request_id: ...] suffix so it only appears
+	// on its own line via FormatError.
+	msg := err.Error()
+	var fallbackReqID string
+	if apiErr != nil && apiErr.RequestID != "" {
+		fallbackReqID = apiErr.RequestID
+		msg = strings.TrimSuffix(msg, fmt.Sprintf(" [request_id: %s]", apiErr.RequestID))
+	}
 	return &CLIError{
-		Err:     err,
-		Message: err.Error(),
+		Err:       err,
+		Message:   msg,
+		RequestID: fallbackReqID,
 	}
 }
 
@@ -252,6 +265,11 @@ func FormatError(err error) string {
 	// Error code (if available)
 	if cliErr.Code != "" {
 		_, _ = Dim.Fprintf(&sb, "  Code: %s\n", cliErr.Code)
+	}
+
+	// Request ID (if available from API response)
+	if cliErr.RequestID != "" {
+		_, _ = Dim.Fprintf(&sb, "  Request ID: %s\n", cliErr.RequestID)
 	}
 
 	// Multiple suggestions (preferred)

--- a/internal/cli/common/errors_test.go
+++ b/internal/cli/common/errors_test.go
@@ -199,6 +199,90 @@ func TestWrapError_APIErrorStatusClassification(t *testing.T) {
 	}
 }
 
+func TestWrapError_PropagatesRequestID(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       *domain.APIError
+		wantReqID string
+	}{
+		{
+			name:      "server error with request ID",
+			err:       &domain.APIError{StatusCode: 500, RequestID: "req-abc-123"},
+			wantReqID: "req-abc-123",
+		},
+		{
+			name:      "rate limit with request ID",
+			err:       &domain.APIError{StatusCode: 429, RequestID: "req-def-456"},
+			wantReqID: "req-def-456",
+		},
+		{
+			name:      "insufficient scopes with request ID",
+			err:       &domain.APIError{StatusCode: 403, Type: "insufficient_scopes", RequestID: "req-scope-789"},
+			wantReqID: "req-scope-789",
+		},
+		{
+			name:      "unclassified status with request ID",
+			err:       &domain.APIError{StatusCode: 401, Type: "unauthorized", Message: "bad token", RequestID: "req-fallback-999"},
+			wantReqID: "req-fallback-999",
+		},
+		{
+			name:      "empty request ID stays empty",
+			err:       &domain.APIError{StatusCode: 500},
+			wantReqID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WrapError(tt.err)
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantReqID, result.RequestID)
+		})
+	}
+}
+
+func TestWrapError_StripsInlineRequestIDFromMessage(t *testing.T) {
+	apiErr := &domain.APIError{
+		StatusCode: 401,
+		Type:       "token.unauthorized_access",
+		Message:    "Bearer token invalid",
+		RequestID:  "req-strip-test",
+	}
+	wrapped := fmt.Errorf("failed to fetch messages: %w", apiErr)
+
+	result := WrapError(wrapped)
+
+	require.NotNil(t, result)
+	assert.Equal(t, "req-strip-test", result.RequestID)
+	assert.NotContains(t, result.Message, "[request_id:")
+	assert.Contains(t, result.Message, "Bearer token invalid")
+}
+
+func TestFormatError_RendersRequestID(t *testing.T) {
+	cliErr := &CLIError{
+		Message:    "Nylas API server error",
+		Code:       ErrCodeServerError,
+		Suggestion: "Try again later",
+		RequestID:  "1120765200-c4c8e151-3414-4448-b884-1498872b0912",
+	}
+
+	result := FormatError(cliErr)
+
+	assert.Contains(t, result, "Request ID: 1120765200-c4c8e151-3414-4448-b884-1498872b0912")
+}
+
+func TestFormatError_OmitsEmptyRequestID(t *testing.T) {
+	cliErr := &CLIError{
+		Message: "Some error",
+		Code:    ErrCodeServerError,
+	}
+
+	result := FormatError(cliErr)
+
+	assert.NotContains(t, result, "Request ID")
+}
+
 func TestWrapError_SecretStorePassphraseRequirement(t *testing.T) {
 	err := fmt.Errorf("%w: %s must be set to unlock the encrypted file store", domain.ErrSecretStoreFailed, "NYLAS_FILE_STORE_PASSPHRASE")
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -87,6 +87,7 @@ type APIError struct {
 	StatusCode int
 	Type       string
 	Message    string
+	RequestID  string
 }
 
 func (e *APIError) Error() string {
@@ -96,17 +97,23 @@ func (e *APIError) Error() string {
 
 	message := strings.TrimSpace(e.Message)
 	errType := strings.TrimSpace(e.Type)
+	var base string
 	switch {
 	case message != "" && errType != "":
-		return fmt.Sprintf("%s: %s (%s)", ErrAPIError, message, errType)
+		base = fmt.Sprintf("%s: %s (%s)", ErrAPIError, message, errType)
 	case message != "":
-		return fmt.Sprintf("%s: %s", ErrAPIError, message)
+		base = fmt.Sprintf("%s: %s", ErrAPIError, message)
 	case errType != "":
-		return fmt.Sprintf("%s: %s", ErrAPIError, errType)
+		base = fmt.Sprintf("%s: %s", ErrAPIError, errType)
 	case e.StatusCode > 0:
-		return fmt.Sprintf("%s: status %d", ErrAPIError, e.StatusCode)
+		base = fmt.Sprintf("%s: status %d", ErrAPIError, e.StatusCode)
+	default:
+		base = ErrAPIError.Error()
 	}
-	return ErrAPIError.Error()
+	if reqID := strings.TrimSpace(e.RequestID); reqID != "" {
+		return fmt.Sprintf("%s [request_id: %s]", base, reqID)
+	}
+	return base
 }
 
 func (e *APIError) Unwrap() error {

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -44,6 +44,17 @@ func TestAPIError_Error(t *testing.T) {
 			err:  nil,
 			want: []string{ErrAPIError.Error()},
 		},
+		{
+			name: "request id appended when present",
+			err:  &APIError{StatusCode: 401, Type: "token.unauthorized_access", Message: "Bearer token invalid", RequestID: "1120765200-c4c8e151-3414-4448-b884-1498872b0912"},
+			want: []string{"Bearer token invalid", "token.unauthorized_access", "request_id: 1120765200-c4c8e151-3414-4448-b884-1498872b0912"},
+		},
+		{
+			name:    "blank request id is omitted",
+			err:     &APIError{StatusCode: 500, RequestID: "   "},
+			want:    []string{"status 500"},
+			wantNot: []string{"request_id"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Extract `request_id` from Nylas API error responses (JSON body with header fallback) and propagate through `APIError` → `CLIError` → `FormatError`
- Display request ID on a dedicated line in CLI error output, giving users an actionable reference for debugging with the platform team
- Strip inline `[request_id: ...]` from the error message in `FormatError` path to avoid duplication while preserving it in `Error()` for logging contexts

## Related docs

Commands affected by improved error output:
- [email list](https://cli.nylas.com/docs/commands/email-list) · [email send](https://cli.nylas.com/docs/commands/email-send) · [email search](https://cli.nylas.com/docs/commands/email-search)
- [calendar events list](https://cli.nylas.com/docs/commands/calendar-events-list) · [calendar events create](https://cli.nylas.com/docs/commands/calendar-events-create)
- [contacts list](https://cli.nylas.com/docs/commands/contacts-list) · [contacts search](https://cli.nylas.com/docs/commands/contacts-search)
- [webhook list](https://cli.nylas.com/docs/commands/webhook-list) · [webhook create](https://cli.nylas.com/docs/commands/webhook-create)

Commands referenced in error suggestions:
- [auth config](https://cli.nylas.com/docs/commands/auth-config) · [auth login](https://cli.nylas.com/docs/commands/auth-login) · [auth list](https://cli.nylas.com/docs/commands/auth-list)
- [auth show](https://cli.nylas.com/docs/commands/auth-show) · [auth switch](https://cli.nylas.com/docs/commands/auth-switch) · [auth status](https://cli.nylas.com/docs/commands/auth-status)

## Test plan

- [ ] `make ci` passes
- [ ] `NYLAS_API_KEY=bogus ./bin/nylas email list fake-grant-id` shows `Request ID:` on its own line, not duplicated in the message
- [ ] Errors without a request ID (e.g. local validation like `nylas email list` with no API key) show no `Request ID:` line
- [ ] Unit tests cover: body extraction, header fallback, request ID propagation through `WrapError`, `FormatError` rendering, blank request ID omission, inline suffix stripping