### PR TITLE
TW-5009: centralize API base URL resolution to respect api.base_url config

### DIFF
--- a/internal/adapters/nylas/client.go
+++ b/internal/adapters/nylas/client.go
@@ -38,8 +38,8 @@ func init() {
 }
 
 const (
-	baseURLUS = "https://api.us.nylas.com"
-	baseURLEU = "https://api.eu.nylas.com"
+	baseURLUS = domain.BaseURLUS
+	baseURLEU = domain.BaseURLEU
 
 	// defaultRateLimit is the default rate limit (requests per second)
 	// Set to 10 requests per second to avoid API quota exhaustion
@@ -106,6 +106,14 @@ func (c *HTTPClient) SetCredentials(clientID, clientSecret, apiKey string) {
 // SetBaseURL sets the base URL (for testing purposes).
 func (c *HTTPClient) SetBaseURL(url string) {
 	c.baseURL = url
+}
+
+// ApplyConfig sets the base URL from the config, preferring API.BaseURL over region.
+func (c *HTTPClient) ApplyConfig(cfg *domain.Config) {
+	if cfg == nil {
+		return
+	}
+	c.baseURL = cfg.ResolveBaseURL()
 }
 
 // SetMaxRetries sets the maximum number of retries (for testing purposes).

--- a/internal/adapters/nylas/client_base_test.go
+++ b/internal/adapters/nylas/client_base_test.go
@@ -44,6 +44,49 @@ func TestHTTPClient_SetRegion(t *testing.T) {
 	})
 }
 
+func TestHTTPClient_ApplyConfig(t *testing.T) {
+	t.Run("nil config is a no-op", func(t *testing.T) {
+		client := nylas.NewHTTPClient()
+		client.ApplyConfig(nil)
+		url := client.BuildAuthURL(domain.ProviderGoogle, "http://localhost", "", "")
+		assert.Contains(t, url, "api.us.nylas.com")
+	})
+
+	t.Run("applies US region", func(t *testing.T) {
+		client := nylas.NewHTTPClient()
+		client.ApplyConfig(&domain.Config{Region: "us"})
+		url := client.BuildAuthURL(domain.ProviderGoogle, "http://localhost", "", "")
+		assert.Contains(t, url, "api.us.nylas.com")
+	})
+
+	t.Run("applies EU region", func(t *testing.T) {
+		client := nylas.NewHTTPClient()
+		client.ApplyConfig(&domain.Config{Region: "eu"})
+		url := client.BuildAuthURL(domain.ProviderGoogle, "http://localhost", "", "")
+		assert.Contains(t, url, "api.eu.nylas.com")
+	})
+
+	t.Run("custom base URL takes precedence", func(t *testing.T) {
+		client := nylas.NewHTTPClient()
+		client.ApplyConfig(&domain.Config{
+			Region: "eu",
+			API:    &domain.APIConfig{BaseURL: "https://api-staging.us.nylas.com"},
+		})
+		url := client.BuildAuthURL(domain.ProviderGoogle, "http://localhost", "", "")
+		assert.Contains(t, url, "api-staging.us.nylas.com")
+	})
+
+	t.Run("empty base URL falls back to region", func(t *testing.T) {
+		client := nylas.NewHTTPClient()
+		client.ApplyConfig(&domain.Config{
+			Region: "eu",
+			API:    &domain.APIConfig{BaseURL: ""},
+		})
+		url := client.BuildAuthURL(domain.ProviderGoogle, "http://localhost", "", "")
+		assert.Contains(t, url, "api.eu.nylas.com")
+	})
+}
+
 func TestHTTPClient_SetCredentials(t *testing.T) {
 	client := nylas.NewHTTPClient()
 	client.SetCredentials("my-client-id", "my-secret", "my-api-key")

--- a/internal/air/server_lifecycle.go
+++ b/internal/air/server_lifecycle.go
@@ -50,7 +50,7 @@ func newServer(addr string, secretStoreFactory func(string) (ports.SecretStore, 
 		hasAPIKey = apiKey != ""
 		if hasAPIKey {
 			client := nylas.NewHTTPClient()
-			client.SetRegion(cfg.Region)
+			client.ApplyConfig(cfg)
 			client.SetCredentials(clientID, clientSecret, apiKey)
 			nylasClient = client
 		}

--- a/internal/cli/auth/config.go
+++ b/internal/cli/auth/config.go
@@ -85,7 +85,12 @@ The CLI only requires your API Key - Client ID is auto-detected.`,
 				fmt.Println("Detecting applications...")
 
 				client := nylasadapter.NewHTTPClient()
-				client.SetRegion(region)
+				cfg, _ := configStore.Load()
+				if cfg != nil && cfg.API != nil && cfg.API.BaseURL != "" {
+					client.ApplyConfig(cfg)
+				} else {
+					client.SetRegion(region)
+				}
 				client.SetCredentials("", "", apiKey) // Only API key needed for ListApplications
 
 				ctx, cancel := common.CreateContext()

--- a/internal/cli/auth/helpers.go
+++ b/internal/cli/auth/helpers.go
@@ -111,11 +111,7 @@ func createConfiguredNylasClient(configStore ports.ConfigStore, secretStore port
 	client := nylasadapter.NewHTTPClient()
 
 	cfg, _ := configStore.Load()
-	if cfg != nil && cfg.API != nil && cfg.API.BaseURL != "" {
-		client.SetBaseURL(cfg.API.BaseURL)
-	} else if cfg != nil {
-		client.SetRegion(cfg.Region)
-	}
+	client.ApplyConfig(cfg)
 
 	apiKey, clientID, clientSecret := getCredentialsWithEnvFallback(secretStore)
 	client.SetCredentials(clientID, clientSecret, apiKey)

--- a/internal/cli/auth/show.go
+++ b/internal/cli/auth/show.go
@@ -60,7 +60,7 @@ Information includes:
 			}
 
 			client := nylas.NewHTTPClient()
-			client.SetRegion(cfg.Region)
+			client.ApplyConfig(cfg)
 			client.SetCredentials(clientID, clientSecret, apiKey)
 
 			// Get grant ID

--- a/internal/cli/common/client.go
+++ b/internal/cli/common/client.go
@@ -86,12 +86,7 @@ func GetNylasClient() (ports.NylasClient, error) {
 	// Create and configure the HTTP client
 	c := nylas.NewHTTPClient()
 
-	// Apply API configuration
-	if cfg.API != nil && cfg.API.BaseURL != "" {
-		c.SetBaseURL(cfg.API.BaseURL)
-	} else {
-		c.SetRegion(cfg.Region)
-	}
+	c.ApplyConfig(cfg)
 
 	c.SetCredentials(clientID, clientSecret, apiKey)
 

--- a/internal/cli/doctor_checks.go
+++ b/internal/cli/doctor_checks.go
@@ -183,10 +183,18 @@ func checkAPICredentials() CheckResult {
 }
 
 func checkNetworkConnectivity() CheckResult {
+	configStore := config.NewDefaultFileStore()
+	cfg, _ := configStore.Load()
+	if cfg == nil {
+		cfg = &domain.Config{Region: "us"}
+	}
+
+	healthURL := cfg.ResolveBaseURL() + "/v3/"
+
 	ctx, cancel := common.CreateContextWithTimeout(domain.TimeoutHealthCheck)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.us.nylas.com/v3/", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", healthURL, nil)
 	if err != nil {
 		return CheckResult{
 			Name:    "Network",
@@ -327,7 +335,7 @@ func checkGrants() CheckResult {
 	}
 
 	client := nylas.NewHTTPClient()
-	client.SetRegion(cfg.Region)
+	client.ApplyConfig(cfg)
 	client.SetCredentials(clientID, clientSecret, apiKey)
 
 	ctx, cancel := common.CreateContextWithTimeout(domain.TimeoutHealthCheck)

--- a/internal/cli/otp/helpers.go
+++ b/internal/cli/otp/helpers.go
@@ -30,7 +30,7 @@ func createOTPService() (*otpapp.Service, error) {
 
 	// Set credentials - check env vars first
 	cfg, _ := configStore.Load()
-	client.SetRegion(cfg.Region)
+	client.ApplyConfig(cfg)
 
 	apiKey := os.Getenv("NYLAS_API_KEY")
 	clientID := os.Getenv("NYLAS_CLIENT_ID")

--- a/internal/cli/setup/application_setup.go
+++ b/internal/cli/setup/application_setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nylas/cli/internal/adapters/config"
 	nylasadapter "github.com/nylas/cli/internal/adapters/nylas"
 	"github.com/nylas/cli/internal/cli/common"
 	"github.com/nylas/cli/internal/domain"
@@ -33,7 +34,13 @@ type CallbackURIProvisionResult struct {
 
 func newAPIKeySetupClient(region, clientID, apiKey string) apiKeySetupClient {
 	client := nylasadapter.NewHTTPClient()
-	client.SetRegion(region)
+	configStore := config.NewDefaultFileStore()
+	cfg, _ := configStore.Load()
+	if cfg != nil && cfg.API != nil && cfg.API.BaseURL != "" {
+		client.ApplyConfig(cfg)
+	} else {
+		client.SetRegion(region)
+	}
 	client.SetCredentials(clientID, "", apiKey)
 	return client
 }

--- a/internal/cli/setup/grants.go
+++ b/internal/cli/setup/grants.go
@@ -31,7 +31,12 @@ type SyncResult struct {
 // so every reader observes the same value.
 func SyncGrants(configStore ports.ConfigStore, grantStore ports.GrantStore, apiKey, clientID, region string) (*SyncResult, error) {
 	client := nylasadapter.NewHTTPClient()
-	client.SetRegion(region)
+	cfg, _ := configStore.Load()
+	if cfg != nil && cfg.API != nil && cfg.API.BaseURL != "" {
+		client.ApplyConfig(cfg)
+	} else {
+		client.SetRegion(region)
+	}
 	client.SetCredentials(clientID, "", apiKey)
 
 	ctx, cancel := common.CreateContext()

--- a/internal/cli/setup/wizard_helpers.go
+++ b/internal/cli/setup/wizard_helpers.go
@@ -153,7 +153,13 @@ func appDisplayName(app domain.GatewayApplication) string {
 // verifyAPIKey checks that an API key works by listing applications.
 func verifyAPIKey(apiKey, region string) error {
 	client := nylasadapter.NewHTTPClient()
-	client.SetRegion(region)
+	configStore := config.NewDefaultFileStore()
+	cfg, _ := configStore.Load()
+	if cfg != nil && cfg.API != nil && cfg.API.BaseURL != "" {
+		client.ApplyConfig(cfg)
+	} else {
+		client.SetRegion(region)
+	}
 	client.SetCredentials("", "", apiKey)
 
 	ctx, cancel := common.CreateContext()
@@ -352,11 +358,7 @@ func buildAuthService(configStore ports.ConfigStore, grantStore ports.GrantStore
 	}
 
 	client := nylasadapter.NewHTTPClient()
-	if cfg.API != nil && cfg.API.BaseURL != "" {
-		client.SetBaseURL(cfg.API.BaseURL)
-	} else {
-		client.SetRegion(cfg.Region)
-	}
+	client.ApplyConfig(cfg)
 	apiKey, _ := secretStore.Get(ports.KeyAPIKey)
 	clientID, _ := secretStore.Get(ports.KeyClientID)
 	clientSecret, _ := secretStore.Get(ports.KeyClientSecret)

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -73,6 +73,22 @@ type APIConfig struct {
 	BaseURL string `yaml:"base_url,omitempty"` // API base URL
 }
 
+const (
+	BaseURLUS = "https://api.us.nylas.com"
+	BaseURLEU = "https://api.eu.nylas.com"
+)
+
+// ResolveBaseURL returns the effective API base URL, preferring API.BaseURL over region.
+func (c *Config) ResolveBaseURL() string {
+	if c.API != nil && c.API.BaseURL != "" {
+		return c.API.BaseURL
+	}
+	if c.Region == "eu" {
+		return BaseURLEU
+	}
+	return BaseURLUS
+}
+
 // DefaultConfig returns a config with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{

--- a/internal/domain/config_extended_test.go
+++ b/internal/domain/config_extended_test.go
@@ -20,6 +20,54 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Nil(t, cfg.API)
 }
 
+func TestResolveBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "defaults to US",
+			cfg:  Config{Region: "us"},
+			want: BaseURLUS,
+		},
+		{
+			name: "EU region",
+			cfg:  Config{Region: "eu"},
+			want: BaseURLEU,
+		},
+		{
+			name: "empty region defaults to US",
+			cfg:  Config{},
+			want: BaseURLUS,
+		},
+		{
+			name: "custom base URL takes precedence over region",
+			cfg: Config{
+				Region: "eu",
+				API:    &APIConfig{BaseURL: "https://api-staging.us.nylas.com"},
+			},
+			want: "https://api-staging.us.nylas.com",
+		},
+		{
+			name: "nil API config uses region",
+			cfg:  Config{Region: "eu", API: nil},
+			want: BaseURLEU,
+		},
+		{
+			name: "empty base URL uses region",
+			cfg:  Config{Region: "eu", API: &APIConfig{BaseURL: ""}},
+			want: BaseURLEU,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.ResolveBaseURL())
+		})
+	}
+}
+
 func TestDefaultWorkingHours(t *testing.T) {
 	schedule := DefaultWorkingHours()
 

--- a/internal/ui/server_config.go
+++ b/internal/ui/server_config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/nylas/cli/internal/adapters/config"
 	nylasadapter "github.com/nylas/cli/internal/adapters/nylas"
 	authapp "github.com/nylas/cli/internal/app/auth"
 	"github.com/nylas/cli/internal/cli/common"
@@ -99,7 +100,13 @@ type setupClient interface {
 
 var newSetupClient = func(region, clientID, apiKey string) setupClient {
 	client := nylasadapter.NewHTTPClient()
-	client.SetRegion(region)
+	configStore := config.NewDefaultFileStore()
+	cfg, _ := configStore.Load()
+	if cfg != nil && cfg.API != nil && cfg.API.BaseURL != "" {
+		client.ApplyConfig(cfg)
+	} else {
+		client.SetRegion(region)
+	}
 	client.SetCredentials(clientID, "", apiKey)
 	return client
 }


### PR DESCRIPTION
## Summary

- Adds `Config.ResolveBaseURL()` in the domain layer to centralize base URL resolution logic (`api.base_url` > region > US default)
- Adds `HTTPClient.ApplyConfig()` as a single entry point replacing scattered `SetRegion()`/`SetBaseURL()` if/else blocks across 10+ call sites
- Fixes `nylas doctor` network check to respect configured base URL instead of hardcoding `api.us.nylas.com`

## Test plan

- [x] Unit tests for `ResolveBaseURL()` — US default, EU region, custom base URL precedence, empty/nil edge cases
- [x] Unit tests for `ApplyConfig()` — nil config no-op, region selection, custom URL override
- [ ] `nylas doctor` reports correct connectivity against configured base URL
- [ ] `nylas auth login` and `nylas init` work with `api.base_url` set in config
- [ ] EU region users unaffected when no `api.base_url` is configured

## Related docs

- https://cli.nylas.com/docs/commands/doctor
- https://cli.nylas.com/docs/commands/init
- https://developer.nylas.com/docs/api/v3/