### PR TITLE
TT-4501: send CLI User-Agent header on dashboard API requests

### DIFF
--- a/internal/adapters/dashboard/account_client_test.go
+++ b/internal/adapters/dashboard/account_client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +29,7 @@ func newAccountClientTestServer(t *testing.T, handler func(t *testing.T, w http.
 			require.NoError(t, json.Unmarshal(rawBody, &body))
 		}
 
+		assert.Equal(t, version.UserAgent(), r.Header.Get("User-Agent"))
 		handler(t, w, r, rawBody, body)
 	}))
 }

--- a/internal/adapters/dashboard/gateway_client.go
+++ b/internal/adapters/dashboard/gateway_client.go
@@ -233,6 +233,7 @@ func (c *GatewayClient) doGraphQL(ctx context.Context, url, query string, variab
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+userToken)
+	setDashboardUserAgent(req)
 	if orgToken != "" {
 		req.Header.Set("X-Nylas-Org", orgToken)
 	}

--- a/internal/adapters/dashboard/gateway_client_test.go
+++ b/internal/adapters/dashboard/gateway_client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -188,6 +189,8 @@ func TestGatewayClientOperations(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, version.UserAgent(), r.Header.Get("User-Agent"))
+
 				var body map[string]any
 				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 				tt.handler(t, w, r, body)

--- a/internal/adapters/dashboard/http.go
+++ b/internal/adapters/dashboard/http.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/version"
 )
 
 const (
@@ -24,6 +25,10 @@ func newNonRedirectClient() *http.Client {
 			return http.ErrUseLastResponse
 		},
 	}
+}
+
+func setDashboardUserAgent(req *http.Request) {
+	req.Header.Set("User-Agent", version.UserAgent())
 }
 
 // doPost sends a JSON POST request and decodes the already-unwrapped payload
@@ -74,6 +79,7 @@ func (c *AccountClient) doPostRaw(ctx context.Context, path string, body any, ex
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	setDashboardUserAgent(req)
 
 	if err := c.setDPoPProof(req, http.MethodPost, fullURL, accessToken); err != nil {
 		return nil, err
@@ -142,6 +148,7 @@ func (c *AccountClient) doGetRaw(ctx context.Context, path string, extraHeaders 
 	if err := c.setDPoPProof(req, http.MethodGet, fullURL, accessToken); err != nil {
 		return nil, err
 	}
+	setDashboardUserAgent(req)
 
 	for k, v := range extraHeaders {
 		req.Header.Set(k, v)

--- a/internal/adapters/dashboard/http_test.go
+++ b/internal/adapters/dashboard/http_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/nylas/cli/internal/domain"
+	"github.com/nylas/cli/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -226,7 +227,7 @@ func TestDashboardAPIError_Error(t *testing.T) {
 func TestDoPostAndGet_Integration(t *testing.T) {
 	// Set up a test server that returns a valid envelope response
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify DPoP header was set
+		assert.Equal(t, version.UserAgent(), r.Header.Get("User-Agent"))
 		if dpop := r.Header.Get("DPoP"); dpop == "" {
 			t.Error("DPoP header not set")
 		}


### PR DESCRIPTION
## Summary
- Adds a custom `User-Agent` header (`nylas-cli/<version> (<os>/<arch>)`) to all dashboard HTTP requests (AccountClient POST/GET and GatewayClient GraphQL)
- Introduces a shared `setDashboardUserAgent` helper in `http.go` to avoid duplication
- Adds test assertions for the header across all three request paths

## Related docs
- https://cli.nylas.com/docs/commands/init
- https://cli.nylas.com/docs/commands/dashboard-login
- https://cli.nylas.com/docs/commands/dashboard-register
- https://cli.nylas.com/docs/commands/dashboard-sso
- https://cli.nylas.com/docs/commands/dashboard-apps-list
- https://cli.nylas.com/docs/commands/dashboard-apps-apikeys-create
- https://developer.nylas.com/docs/dev-guide/provider-guides/

## Test plan
- [x] Unit tests assert `User-Agent` header on AccountClient requests (`account_client_test.go`)
- [x] Unit tests assert `User-Agent` header on GatewayClient requests (`gateway_client_test.go`)
- [x] Integration test asserts `User-Agent` header on doPost/doGet (`http_test.go`)
- [x] All tests pass locally