### PR TITLE
TW-5059: fix WrapError request ID false-match and classification gaps

### DIFF
--- a/internal/adapters/nylas/client.go
+++ b/internal/adapters/nylas/client.go
@@ -472,8 +472,7 @@ func (c *HTTPClient) doJSONRequestInternalWithRetry(
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set headers
-	req.Header.Set("User-Agent", version.UserAgent())
+	// Set request-specific headers
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/cli/common/errors.go
+++ b/internal/cli/common/errors.go
@@ -89,6 +89,40 @@ func WrapError(err error) *CLIError {
 				Code:       ErrCodeServerError,
 				RequestID:  apiErr.RequestID,
 			}
+		case apiErr.StatusCode == http.StatusUnauthorized:
+			return &CLIError{
+				Err:        err,
+				Message:    "Authentication failed",
+				Suggestion: "Check your API key with 'nylas auth status' or reconfigure with 'nylas auth config'",
+				Code:       ErrCodeAuthFailed,
+				RequestID:  apiErr.RequestID,
+			}
+		case apiErr.StatusCode == http.StatusForbidden:
+			return &CLIError{
+				Err:        err,
+				Message:    "Permission denied",
+				Suggestion: "Check that your API key has the required permissions",
+				Code:       ErrCodePermissionDenied,
+				RequestID:  apiErr.RequestID,
+			}
+		case apiErr.StatusCode == http.StatusNotFound:
+			return &CLIError{
+				Err:        err,
+				Message:    "Resource not found",
+				Suggestion: "Verify the ID exists with the appropriate 'list' command",
+				Code:       ErrCodeNotFound,
+				RequestID:  apiErr.RequestID,
+			}
+		default:
+			msg := apiErr.Error()
+			if apiErr.RequestID != "" {
+				msg = strings.TrimSuffix(msg, fmt.Sprintf(" [request_id: %s]", apiErr.RequestID))
+			}
+			return &CLIError{
+				Err:       err,
+				Message:   msg,
+				RequestID: apiErr.RequestID,
+			}
 		}
 	}
 
@@ -234,19 +268,9 @@ func WrapError(err error) *CLIError {
 		}
 	}
 
-	// Default wrapper — extract request ID from APIError if present,
-	// and strip the inline [request_id: ...] suffix so it only appears
-	// on its own line via FormatError.
-	msg := err.Error()
-	var fallbackReqID string
-	if apiErr != nil && apiErr.RequestID != "" {
-		fallbackReqID = apiErr.RequestID
-		msg = strings.TrimSuffix(msg, fmt.Sprintf(" [request_id: %s]", apiErr.RequestID))
-	}
 	return &CLIError{
-		Err:       err,
-		Message:   msg,
-		RequestID: fallbackReqID,
+		Err:     err,
+		Message: err.Error(),
 	}
 }
 

--- a/internal/cli/common/errors_test.go
+++ b/internal/cli/common/errors_test.go
@@ -150,13 +150,12 @@ func TestWrapError_InsufficientScopes(t *testing.T) {
 }
 
 func TestWrapError_GenericForbiddenFallsThrough(t *testing.T) {
-	// 403 without insufficient_scopes type should fall through to default
-	// wrapper, not get the scope-specific suggestion.
 	apiErr := &domain.APIError{StatusCode: 403, Message: "Access denied"}
 	result := WrapError(apiErr)
 
 	require.NotNil(t, result)
-	assert.NotEqual(t, ErrCodePermissionDenied, result.Code, "generic 403 should not be classified as scope error")
+	assert.Equal(t, ErrCodePermissionDenied, result.Code)
+	assert.Equal(t, "Permission denied", result.Message)
 	for _, s := range result.Suggestions {
 		assert.NotContains(t, s, "auth show", "generic 403 should not get scope-specific suggestion")
 	}
@@ -171,18 +170,39 @@ func TestWrapError_APIErrorStatusClassification(t *testing.T) {
 		wantSuggest string
 	}{
 		{
-			name:        "type only rate limit",
+			name:        "rate limit 429",
 			err:         &domain.APIError{StatusCode: 429, Type: "api_error"},
 			wantMessage: "Rate limit exceeded",
 			wantCode:    ErrCodeRateLimited,
 			wantSuggest: "reduce the frequency",
 		},
 		{
-			name:        "type only server error",
+			name:        "server error 500",
 			err:         &domain.APIError{StatusCode: 500, Type: "api_error"},
 			wantMessage: "Nylas API server error",
 			wantCode:    ErrCodeServerError,
 			wantSuggest: "temporary issue",
+		},
+		{
+			name:        "unauthorized 401",
+			err:         &domain.APIError{StatusCode: 401, Type: "unauthorized", Message: "Invalid API Key"},
+			wantMessage: "Authentication failed",
+			wantCode:    ErrCodeAuthFailed,
+			wantSuggest: "nylas auth status",
+		},
+		{
+			name:        "forbidden 403",
+			err:         &domain.APIError{StatusCode: 403, Message: "Access denied"},
+			wantMessage: "Permission denied",
+			wantCode:    ErrCodePermissionDenied,
+			wantSuggest: "required permissions",
+		},
+		{
+			name:        "not found 404",
+			err:         &domain.APIError{StatusCode: 404, Message: "Not found"},
+			wantMessage: "Resource not found",
+			wantCode:    ErrCodeNotFound,
+			wantSuggest: "list",
 		},
 	}
 
@@ -195,6 +215,41 @@ func TestWrapError_APIErrorStatusClassification(t *testing.T) {
 			assert.Equal(t, tt.wantCode, result.Code)
 			assert.Contains(t, result.Suggestion, tt.wantSuggest)
 			assert.True(t, errors.Is(result, domain.ErrAPIError))
+		})
+	}
+}
+
+func TestWrapError_RequestIDDoesNotFalseMatchStatusCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *domain.APIError
+		wantCode string
+	}{
+		{
+			name:     "request ID containing 502 on a 401 error",
+			err:      &domain.APIError{StatusCode: 401, Message: "bad token", RequestID: "req-5023-abc"},
+			wantCode: ErrCodeAuthFailed,
+		},
+		{
+			name:     "request ID containing 429 on a 404 error",
+			err:      &domain.APIError{StatusCode: 404, Message: "not found", RequestID: "req-4291-def"},
+			wantCode: ErrCodeNotFound,
+		},
+		{
+			name:     "request ID containing 500 on a 403 error",
+			err:      &domain.APIError{StatusCode: 403, Message: "forbidden", RequestID: "req-5001-xyz"},
+			wantCode: ErrCodePermissionDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := fmt.Errorf("API call failed: %w", tt.err)
+			result := WrapError(wrapped)
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantCode, result.Code)
+			assert.Equal(t, tt.err.RequestID, result.RequestID)
 		})
 	}
 }
@@ -244,19 +299,19 @@ func TestWrapError_PropagatesRequestID(t *testing.T) {
 
 func TestWrapError_StripsInlineRequestIDFromMessage(t *testing.T) {
 	apiErr := &domain.APIError{
-		StatusCode: 401,
-		Type:       "token.unauthorized_access",
-		Message:    "Bearer token invalid",
+		StatusCode: 400,
+		Type:       "invalid_request",
+		Message:    "Missing required field",
 		RequestID:  "req-strip-test",
 	}
-	wrapped := fmt.Errorf("failed to fetch messages: %w", apiErr)
+	wrapped := fmt.Errorf("failed to create event: %w", apiErr)
 
 	result := WrapError(wrapped)
 
 	require.NotNil(t, result)
 	assert.Equal(t, "req-strip-test", result.RequestID)
 	assert.NotContains(t, result.Message, "[request_id:")
-	assert.Contains(t, result.Message, "Bearer token invalid")
+	assert.Contains(t, result.Message, "Missing required field")
 }
 
 func TestFormatError_RendersRequestID(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix two bugs in `WrapError` where `APIError` instances with status 401/403/404 fell through to string-matching on `err.Error()`, which since PR #80 includes `[request_id: ...]` — a request ID containing "502" or "429" as a substring could misclassify the error, and all string-match paths silently dropped the request ID
- Extend the structured switch to handle 401 (auth failed), 403 (permission denied), 404 (not found), and a default catch-all so every `APIError` is classified by status code with `RequestID` preserved
- Remove redundant User-Agent header set in `doJSONRequestInternalWithRetry` (already set by `doRequest`/`doRequestNoRetry`)

## Test plan

- [x] `TestWrapError_RequestIDDoesNotFalseMatchStatusCode` — regression test proving request IDs containing "502", "429", "500" don't cause misclassification
- [x] `TestWrapError_APIErrorStatusClassification` — expanded with 401, 403, 404 cases
- [x] `TestWrapError_PropagatesRequestID` — all status code paths carry request ID
- [x] `TestWrapError_GenericForbiddenFallsThrough` — generic 403 gets permission denied, not scope-specific suggestions
- [x] `TestHTTPClient_UserAgent` — User-Agent still sent on all requests after removing redundant set
- [x] `make ci-full` passes (4 pre-existing scheduler 404 failures unrelated to this change)

## Related docs

- https://cli.nylas.com/docs/commands/auth-status — error output references this command in 401 suggestions
- https://cli.nylas.com/docs/commands/auth-config — error output references this command in 401 suggestions
- https://cli.nylas.com/docs/commands/doctor — affected by error classification changes