### PR TITLE
TW-5078: add multi-arch Docker build (amd64+arm64) on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        if: github.event_name == 'push'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -76,16 +80,21 @@ jobs:
           docker run --rm nylas-cli:test commands --json >/tmp/nylas-commands.json
           jq empty /tmp/nylas-commands.json
 
-      - name: Push to GHCR
+      - name: Build and push multi-arch image to GHCR
         if: github.event_name == 'push'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           SHA: ${{ github.sha }}
-        run: |
-          short_sha="${SHA:0:7}"
-          docker tag nylas-cli:test "ghcr.io/nylas/cli:main"
-          docker tag nylas-cli:test "ghcr.io/nylas/cli:sha-${short_sha}"
-          docker push ghcr.io/nylas/cli:main
-          docker push "ghcr.io/nylas/cli:sha-${short_sha}"
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/nylas/cli:main
+            ghcr.io/nylas/cli:sha-${{ github.sha }}
+          build-args: |
+            VERSION=ci
+            COMMIT=${{ github.sha }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add QEMU setup step for arm64 cross-compilation on merge to main
- Replace single-platform `docker tag`/`docker push` with `build-push-action` multi-platform build (linux/amd64 + linux/arm64)
- PR builds remain single-platform (amd64 only) for speed

**Before:** `ghcr.io/nylas/cli:main` was linux/amd64 only — Apple Silicon users got a platform mismatch warning
**After:** `ghcr.io/nylas/cli:main` is multi-arch, runs natively on both amd64 and arm64

## Test plan

- [ ] CI passes on this PR (docker job builds single-platform + smoke test)
- [ ] After merge, verify `ghcr.io/nylas/cli:main` includes both platforms: `docker manifest inspect ghcr.io/nylas/cli:main`
- [ ] Verify on Apple Silicon: `docker run --rm ghcr.io/nylas/cli:main --version` runs without platform warning

## Related docs

- https://cli.nylas.com/docs/commands/init — referenced in Docker setup docs