### PR TITLE
TW-5079: add NYLAS_API_BASE_URL env var to override API base URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Go 1.24+ · Hexagonal architecture (CLI → Port → Adapter) · Cobra CLI · **
 | Hook enforcement | `.claude/HOOKS-CONFIG.md` |
 | Agent definitions | `.claude/agents/README.md` |
 
-**Env vars:** `NYLAS_DISABLE_KEYRING`, `NYLAS_API_KEY`, `NYLAS_CLIENT_ID`, `NYLAS_GRANT_ID` — see `docs/DEVELOPMENT.md`
+**Env vars:** `NYLAS_DISABLE_KEYRING`, `NYLAS_API_KEY`, `NYLAS_CLIENT_ID`, `NYLAS_GRANT_ID`, `NYLAS_API_BASE_URL` — see `docs/DEVELOPMENT.md`
 
 **Credentials:** System keyring (service: `"nylas"`, keys: `client_id`, `api_key`, `client_secret`, `org_id`). Grant cache: `os.UserCacheDir()/nylas/grants.json`. Fallback: `~/.config/nylas/` with `NYLAS_DISABLE_KEYRING=true`.
 

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -39,6 +39,16 @@ docker run --rm \
   calendar list --json
 ```
 
+To target a different API environment (staging, EU):
+
+```bash
+docker run --rm \
+  -e NYLAS_API_KEY="$NYLAS_API_KEY" \
+  -e NYLAS_API_BASE_URL="https://api.eu.nylas.com" \
+  ghcr.io/nylas/cli:latest \
+  email list --limit 5 --json
+```
+
 Do not bake API keys or credentials into the image.
 
 ---

--- a/internal/cli/common/client.go
+++ b/internal/cli/common/client.go
@@ -88,6 +88,10 @@ func GetNylasClient() (ports.NylasClient, error) {
 
 	c.ApplyConfig(cfg)
 
+	if baseURL := os.Getenv("NYLAS_API_BASE_URL"); baseURL != "" {
+		c.SetBaseURL(baseURL)
+	}
+
 	c.SetCredentials(clientID, clientSecret, apiKey)
 
 	return c, nil


### PR DESCRIPTION
## Summary

- Add `NYLAS_API_BASE_URL` environment variable support in `GetNylasClient()`
- Env var overrides both config file `api.base_url` and region default
- No effect when unset — existing behavior unchanged

Priority order: `NYLAS_API_BASE_URL` env var > `api.base_url` config > region default

```bash
docker run --rm \
  -e NYLAS_API_KEY="$NYLAS_API_KEY" \
  -e NYLAS_API_BASE_URL="https://api.eu.nylas.com" \
  ghcr.io/nylas/cli:latest \
  email list --limit 5 --json
```

## Test plan

- [ ] CI passes
- [ ] `NYLAS_API_BASE_URL=https://api.eu.nylas.com nylas auth status` hits EU endpoint
- [ ] Without env var set, behavior is unchanged
- [ ] `nylas config set api.base_url` still works when env var is unset

## Related docs

- https://cli.nylas.com/docs/commands/auth-config — credential configuration
- https://cli.nylas.com/docs/commands/init — setup wizard