### PR TITLE
TW-5081: add Linux package support (deb, rpm, apk, archlinux) via GoReleaser nfpms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ CLAUDE.local.md
 claude-progress.txt
 # Build artifacts
 dist/
+completions/
 
 # Binaries
 bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,10 @@ project_name: nylas
 before:
   hooks:
     - go mod tidy
+    - mkdir -p completions
+    - sh -c "go run ./cmd/nylas completion bash > completions/nylas.bash"
+    - sh -c "go run ./cmd/nylas completion zsh > completions/nylas.zsh"
+    - sh -c "go run ./cmd/nylas completion fish > completions/nylas.fish"
 
 builds:
   - main: ./cmd/nylas
@@ -44,6 +48,42 @@ archives:
       - README.md
       - LICENSE*
       - docs/*
+
+nfpms:
+  - id: nylas-cli
+    package_name: nylas
+    vendor: Nylas
+    homepage: https://cli.nylas.com/
+    maintainer: Nylas <support@nylas.com>
+    description: CLI for Nylas API - manage email, calendar, and contacts
+    license: MIT
+    formats:
+      - deb
+      - rpm
+      - apk
+      - archlinux
+    scripts:
+      postinstall: scripts/postinstall.sh
+    bindir: /usr/bin
+    section: utils
+    priority: optional
+    contents:
+      - src: completions/nylas.bash
+        dst: /usr/share/bash-completion/completions/nylas
+      - src: completions/nylas.zsh
+        dst: /usr/share/zsh/vendor-completions/_nylas
+        packager: deb
+      - src: completions/nylas.zsh
+        dst: /usr/share/zsh/vendor-completions/_nylas
+        packager: apk
+      - src: completions/nylas.zsh
+        dst: /usr/share/zsh/site-functions/_nylas
+        packager: rpm
+      - src: completions/nylas.zsh
+        dst: /usr/share/zsh/site-functions/_nylas
+        packager: archlinux
+      - src: completions/nylas.fish
+        dst: /usr/share/fish/vendor_completions.d/nylas.fish
 
 checksum:
   name_template: 'checksums.txt'
@@ -112,6 +152,24 @@ release:
     - Intel: Download `Nylas-CLI-{{ .Version }}-intel.dmg`
 
     Open the DMG and copy `nylas` to `/usr/local/bin/` or your preferred location.
+
+    **Linux (deb/rpm/apk):**
+    ```bash
+    # Debian/Ubuntu
+    sudo dpkg -i nylas_{{ .Version }}_linux_amd64.deb
+
+    # RHEL/Fedora
+    sudo rpm -i nylas_{{ .Version }}_linux_amd64.rpm
+
+    # Alpine
+    sudo apk add --allow-untrusted nylas_{{ .Version }}_linux_amd64.apk
+    ```
+
+    **Docker:**
+    ```bash
+    docker pull ghcr.io/nylas/cli:{{ .Version }}
+    docker run --rm ghcr.io/nylas/cli:{{ .Version }} --help
+    ```
 
     **Manual Download:**
     Download the appropriate archive for your platform below, extract it, and move the `nylas` binary to your PATH.

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo ""
+echo "Nylas CLI installed successfully!"
+echo "Run 'nylas init' to get started."
+echo ""


### PR DESCRIPTION
## Summary

- Adds `nfpms:` config to `.goreleaser.yml` producing deb, rpm, apk, and archlinux packages (amd64 + arm64)
- Generates shell completions (bash, zsh, fish) via before hooks, included in all packages
- Adds post-install script showing setup instructions
- Updates release notes template with Linux and Docker install instructions

Each release will automatically produce 8 additional assets on the GitHub Release page. No CI workflow changes required — GoReleaser handles it in the existing release job.

## Test plan

- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean --skip=publish` produces all 8 packages successfully
- [x] Existing archives (tar.gz/zip) generated identically
- [x] Docker workflow unaffected (pattern matches only `.tar.gz`)
- [x] Zsh completion paths correct per distro (vendor-completions for deb/apk, site-functions for rpm/archlinux)
- [ ] Verify packages install cleanly on target distros (post-merge)

## Related docs

- https://cli.nylas.com/docs/commands/completion-bash
- https://cli.nylas.com/docs/commands/completion-zsh
- https://cli.nylas.com/docs/commands/completion-fish
- https://cli.nylas.com/docs/commands/init