### PR TITLE
TW-5092: add AUR package publishing to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,32 @@ jobs:
       - name: Run tests
         run: go test ./... -short
 
+      - name: Set up AUR SSH key
+        if: github.event_name == 'push'
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$AUR_SSH_PRIVATE_KEY" ]; then
+            echo "::error::AUR_SSH_PRIVATE_KEY secret is required to publish the AUR package"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          aur_key_path="$HOME/.ssh/aur_ed25519"
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$aur_key_path"
+          chmod 600 "$aur_key_path"
+          aur_known_hosts="$(mktemp)"
+          ssh-keyscan -t ed25519 aur.archlinux.org > "$aur_known_hosts" 2>/dev/null
+          if ! ssh-keygen -lf "$aur_known_hosts" | grep -Fq 'SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4'; then
+            echo "::error::AUR host key fingerprint did not match the expected ed25519 fingerprint"
+            exit 1
+          fi
+          cat "$aur_known_hosts" >> ~/.ssh/known_hosts
+          rm -f "$aur_known_hosts"
+          chmod 600 ~/.ssh/known_hosts
+          printf '%s\n' 'Host aur.archlinux.org' "  IdentityFile $aur_key_path" '  User aur' >> ~/.ssh/config
+          echo "AUR_SSH_KEY_PATH=$aur_key_path" >> "$GITHUB_ENV"
+
       - name: Validate release build
         if: github.event_name == 'workflow_dispatch'
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,6 +85,28 @@ nfpms:
       - src: completions/nylas.fish
         dst: /usr/share/fish/vendor_completions.d/nylas.fish
 
+aurs:
+  - name: nylas
+    homepage: https://cli.nylas.com/
+    description: CLI for Nylas API - manage email, calendar, and contacts
+    maintainers:
+      - "Nylas <support@nylas.com>"
+    license: MIT
+    private_key: "{{ .Env.AUR_SSH_KEY_PATH }}"
+    git_url: "ssh://aur@aur.archlinux.org/nylas.git"
+    disable: "{{ .IsSnapshot }}"
+    depends:
+      - glibc
+    optdepends:
+      - "bash-completion: for bash completions"
+      - "zsh: for zsh completions"
+      - "fish: for fish completions"
+    package: |-
+      install -Dm755 nylas "${pkgdir}/usr/bin/nylas"
+      install -Dm644 completions/nylas.bash "${pkgdir}/usr/share/bash-completion/completions/nylas"
+      install -Dm644 completions/nylas.zsh "${pkgdir}/usr/share/zsh/site-functions/_nylas"
+      install -Dm644 completions/nylas.fish "${pkgdir}/usr/share/fish/vendor_completions.d/nylas.fish"
+
 checksum:
   name_template: 'checksums.txt'
 
@@ -163,6 +185,13 @@ release:
 
     # Alpine
     sudo apk add --allow-untrusted nylas_{{ .Version }}_linux_amd64.apk
+    ```
+
+    **Arch Linux (AUR):**
+    ```bash
+    yay -S nylas
+    # or
+    paru -S nylas
     ```
 
     **Docker:**


### PR DESCRIPTION
## Summary
- Add GoReleaser `aurs` section to publish the Nylas CLI as an AUR package (`nylas`) on each release
- Add CI step to set up AUR SSH key with host key fingerprint verification before GoReleaser runs
- Add Arch Linux install instructions (`yay -S nylas` / `paru -S nylas`) to release notes template

## Setup required
- Generate ed25519 SSH keypair and register public key with AUR account
- Add `AUR_SSH_PRIVATE_KEY` as a GitHub Actions secret
- Create the `nylas` package on AUR (initial push to reserve the name)

## Test plan
- [ ] Verify `goreleaser check` passes with updated `.goreleaser.yml`
- [ ] Run a snapshot build (`goreleaser release --snapshot --skip=publish`) to confirm AUR section is valid
- [ ] Verify SSH key setup step runs correctly in CI (dry run on non-push event)
- [ ] After merging, confirm AUR package is published on next release tag

## Related docs
- https://cli.nylas.com/docs/commands/init
- https://developer.nylas.com/docs/dev-guide/quickstart/