### PR TITLE
TW-5097: fix stale dashboard URLs and AUR release pipeline

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,7 +93,7 @@ aurs:
       - "Nylas <support@nylas.com>"
     license: MIT
     private_key: "{{ .Env.AUR_SSH_KEY_PATH }}"
-    git_url: "ssh://aur@aur.archlinux.org/nylas.git"
+    git_url: "ssh://aur@aur.archlinux.org/nylas-bin.git"
     disable: "{{ .IsSnapshot }}"
     depends:
       - glibc

--- a/internal/cli/auth/config.go
+++ b/internal/cli/auth/config.go
@@ -164,7 +164,7 @@ The CLI only requires your API Key - Client ID is auto-detected.`,
 				fmt.Printf("  Please add this callback URI manually in the Nylas dashboard:\n")
 				fmt.Printf("    %s\n", callbackResult.RequiredURI)
 				fmt.Println()
-				fmt.Printf("  Dashboard: https://dashboard.nylas.com/applications\n")
+				fmt.Printf("  Dashboard: https://dashboard-v3.nylas.com/applications\n")
 				fmt.Printf("  Navigate to: Your App → Settings → Callback URIs → Add URI\n")
 			} else if callbackResult.Created {
 				_, _ = common.Green.Printf("  ✓ Added callback URI: %s\n", callbackResult.RequiredURI)

--- a/internal/cli/common/client.go
+++ b/internal/cli/common/client.go
@@ -79,7 +79,7 @@ func GetNylasClient() (ports.NylasClient, error) {
 			"API key not configured",
 			"Configure with: nylas auth config",
 			"Or use environment variable: export NYLAS_API_KEY=<your-key>",
-			"Get your API key from: https://dashboard.nylas.com",
+			"Get your API key from: https://dashboard-v3.nylas.com",
 		)
 	}
 
@@ -144,7 +144,7 @@ func GetAPIKey() (string, error) {
 			"API key not configured",
 			"Configure with: nylas auth config",
 			"Or use environment variable: export NYLAS_API_KEY=<your-key>",
-			"Get your API key from: https://dashboard.nylas.com",
+			"Get your API key from: https://dashboard-v3.nylas.com",
 		)
 	}
 

--- a/internal/cli/setup/wizard_helpers.go
+++ b/internal/cli/setup/wizard_helpers.go
@@ -203,7 +203,7 @@ func printCallbackURIManualInstructions(requiredCallbackURI string, err error) {
 	fmt.Printf("  Please add this callback URI manually in the Nylas dashboard:\n")
 	fmt.Printf("    %s\n", requiredCallbackURI)
 	fmt.Println()
-	fmt.Printf("  Dashboard: https://dashboard.nylas.com/applications\n")
+	fmt.Printf("  Dashboard: https://dashboard-v3.nylas.com/applications\n")
 	fmt.Printf("  Navigate to: Your App → Settings → Callback URIs → Add URI\n")
 }
 


### PR DESCRIPTION
## Summary

- Fix 4 stale `dashboard.nylas.com` references → `dashboard-v3.nylas.com` (reported in #86)
- Fix AUR release failure by changing `git_url` from `nylas.git` → `nylas-bin.git` to match the `pkgbase=nylas-bin` that GoReleaser auto-generates ([failed run](https://github.com/nylas/cli/actions/runs/26113341100))

## Related docs

- https://cli.nylas.com/docs/commands/init
- https://cli.nylas.com/docs/commands/auth-config

## Test plan

- [x] `go build ./...` passes
- [x] Unit tests pass for affected packages (`auth`, `setup`, `common`, `ui`)
- [x] No remaining stale `dashboard.nylas.com` references in non-test Go files
- [ ] Re-run release pipeline to verify AUR publish succeeds