### PR TITLE
TW-5118: fix AUR package build by including completions in release archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,7 @@ archives:
       - README.md
       - LICENSE*
       - docs/*
+      - completions/*
 
 nfpms:
   - id: nylas-cli


### PR DESCRIPTION
## Summary

- AUR package (`nylas-bin`) fails to build because shell completion files are missing from the release tar.gz archive
- Added `completions/*` to `.goreleaser.yml` `archives.files` so the generated bash/zsh/fish completions are bundled in the GitHub release archive
- The `nfpms` packager (deb/rpm/apk/archlinux) was unaffected because it accesses completions directly during CI build, but the AUR flow downloads the archive separately

## Related docs

- https://cli.nylas.com/docs/commands/completion-bash
- https://cli.nylas.com/docs/commands/completion-zsh
- https://cli.nylas.com/docs/commands/completion-fish

## Test plan

- [ ] Tag a release and verify the tar.gz archive contains `completions/nylas.{bash,zsh,fish}`
- [ ] Install from AUR (`yay -S nylas-bin`) and confirm `package()` succeeds
- [ ] Verify shell completions work after AUR install (`nylas <tab>`)