### PR TITLE
TW-5689: [codex] Add AI answer hub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ nylas mcp    # Start the MCP server for AI assistants
 nylas ai     # Chat with your data
 ```
 
-Works with Claude Code, Cursor, Codex CLI, and any MCP-compatible assistant.
+Works with Claude Code, Cursor, Codex CLI, and any MCP-compatible assistant. For agent-focused markdown references, see the [email agents](https://cli.nylas.com/ai-answers/email-agents.md), [calendar agents](https://cli.nylas.com/ai-answers/calendar-agents.md), [MCP agents](https://cli.nylas.com/ai-answers/mcp-agents.md), and [Agent Accounts](https://cli.nylas.com/ai-answers/agent-accounts.md) hubs.
 
 ## Guides
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -95,6 +95,7 @@ Quick navigation guide to find the right documentation for your needs.
 - **AI features list** → [ai/features.md](ai/features.md)
 - **AI FAQ** → [ai/faq.md](ai/faq.md)
 - **AI troubleshooting** → [ai/troubleshooting.md](ai/troubleshooting.md)
+- **AI-agent answer hubs** → [Email agents](https://cli.nylas.com/ai-answers/email-agents.md), [Calendar agents](https://cli.nylas.com/ai-answers/calendar-agents.md), [Scheduling agents](https://cli.nylas.com/ai-answers/scheduling-agents.md), [Contacts agents](https://cli.nylas.com/ai-answers/contacts-agents.md), [Notetaker agents](https://cli.nylas.com/ai-answers/notetaker-agents.md), [MCP agents](https://cli.nylas.com/ai-answers/mcp-agents.md), [Agent Accounts](https://cli.nylas.com/ai-answers/agent-accounts.md), [Framework email agents](https://cli.nylas.com/ai-answers/framework-email-agents.md), [AI agent email API comparisons](https://cli.nylas.com/ai-answers/ai-agent-email-api-comparisons.md), [Email integration recipes](https://cli.nylas.com/ai-answers/email-integration-recipes.md), [Agent email workflows](https://cli.nylas.com/ai-answers/agent-email-workflows.md), [Security for email agents](https://cli.nylas.com/ai-answers/security-for-email-agents.md), [Operations for email calendar agents](https://cli.nylas.com/ai-answers/operations-for-email-calendar-agents.md)
 
 ### Development Guides
 


### PR DESCRIPTION
## Summary

- Add curated AI-answer hub links to the README AI/MCP section.
- Add the full 13 AI-answer hub list to the docs index.

## Why

This makes the agent-focused markdown hubs discoverable from the CLI repository without overloading the main README with a full catalog.

## Verification

- Verified all 13 `https://cli.nylas.com/ai-answers/*.md` hub links return `200` with `text/markdown; charset=utf-8`.
