### PR TITLE
TW-5658: fix drafts list timestamps and add `drafts list --id` flag

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -335,6 +335,7 @@ nylas email threads delete <thread-id>             # Delete thread
 
 ```bash
 nylas email drafts list                           # List drafts
+nylas email drafts list --id                      # Show full draft IDs
 nylas email drafts show <draft-id>                # Show draft details
 nylas email drafts create --to EMAIL --subject S  # Create draft
 nylas email drafts create --to EMAIL --subject S --signature-id SIG  # Create draft with stored signature

--- a/internal/adapters/nylas/drafts.go
+++ b/internal/adapters/nylas/drafts.go
@@ -51,8 +51,12 @@ type draftResponse struct {
 		ContentType string `json:"content_type"`
 		Size        int64  `json:"size"`
 	} `json:"attachments"`
-	CreatedAt int64 `json:"created_at"`
-	UpdatedAt int64 `json:"updated_at"`
+	CreatedAt domain.UnixTime `json:"created_at"`
+	UpdatedAt domain.UnixTime `json:"updated_at"`
+	// Date is the draft's compose/last-saved time. The Nylas v3 drafts API
+	// returns created_at/updated_at as null and puts the real timestamp here,
+	// mirroring the message `date` field.
+	Date domain.UnixTime `json:"date"`
 }
 
 // GetDrafts retrieves drafts for a grant.
@@ -400,7 +404,21 @@ func convertDraft(d draftResponse) domain.Draft {
 		ReplyToMsgID: d.ReplyToMsgID,
 		ThreadID:     d.ThreadID,
 		Attachments:  util.Map(d.Attachments, convertAttachment),
-		CreatedAt:    time.Unix(d.CreatedAt, 0),
-		UpdatedAt:    time.Unix(d.UpdatedAt, 0),
+		// The Nylas v3 drafts API returns created_at/updated_at as null
+		// (decoded to the Unix epoch); fall back to the `date` field so drafts
+		// don't render as 1970.
+		CreatedAt: firstSetTime(d.CreatedAt, d.Date),
+		UpdatedAt: firstSetTime(d.UpdatedAt, d.Date),
 	}
+}
+
+// firstSetTime returns primary when it is populated, otherwise fallback. The
+// Nylas v3 drafts API leaves created_at/updated_at unset in two ways: omitted
+// entirely (decodes to the zero time, year 1) or sent as null (decodes to the
+// Unix epoch). Both count as unset, so we fall back to the `date` field.
+func firstSetTime(primary, fallback domain.UnixTime) time.Time {
+	if !primary.IsZero() && primary.Unix() != 0 {
+		return primary.Time
+	}
+	return fallback.Time
 }

--- a/internal/adapters/nylas/drafts_unit_test.go
+++ b/internal/adapters/nylas/drafts_unit_test.go
@@ -4,11 +4,19 @@
 package nylas
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/nylas/cli/internal/domain"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// ut builds a domain.UnixTime from Unix seconds for draftResponse fixtures.
+func ut(sec int64) domain.UnixTime {
+	return domain.UnixTime{Time: time.Unix(sec, 0)}
+}
 
 func TestConvertDraft(t *testing.T) {
 	now := time.Now().Unix()
@@ -63,8 +71,8 @@ func TestConvertDraft(t *testing.T) {
 				Size:        50000,
 			},
 		},
-		CreatedAt: now - 3600,
-		UpdatedAt: now,
+		CreatedAt: ut(now - 3600),
+		UpdatedAt: ut(now),
 	}
 
 	draft := convertDraft(apiDraft)
@@ -120,8 +128,8 @@ func TestConvertDrafts(t *testing.T) {
 			}{
 				{Name: "User1", Email: "user1@example.com"},
 			},
-			CreatedAt: now,
-			UpdatedAt: now,
+			CreatedAt: ut(now),
+			UpdatedAt: ut(now),
 		},
 		{
 			ID:      "draft-2",
@@ -134,8 +142,8 @@ func TestConvertDrafts(t *testing.T) {
 			}{
 				{Name: "User2", Email: "user2@example.com"},
 			},
-			CreatedAt: now,
-			UpdatedAt: now,
+			CreatedAt: ut(now),
+			UpdatedAt: ut(now),
 		},
 	}
 
@@ -154,4 +162,51 @@ func TestConvertDrafts_Empty(t *testing.T) {
 	drafts := convertDrafts([]draftResponse{})
 	assert.NotNil(t, drafts)
 	assert.Len(t, drafts, 0)
+}
+
+// TestConvertDraft_DateFallback verifies that drafts use the `date` field for
+// timestamps. The Nylas v3 drafts API carries the real timestamp in `date` and
+// leaves created_at/updated_at unset — without this fallback the CLI renders
+// every draft at the zero time ("292 years ago") or the Unix epoch.
+//
+// The two cases are decoded from raw JSON so the test exercises the real
+// unmarshal path: created_at/updated_at omitted (decodes to the zero time) and
+// sent as null (decodes to the Unix epoch).
+func TestConvertDraft_DateFallback(t *testing.T) {
+	date := int64(1782059501)
+
+	cases := map[string]string{
+		"omitted": `{"id":"d","date":1782059501}`,
+		"null":    `{"id":"d","created_at":null,"updated_at":null,"date":1782059501}`,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			var d draftResponse
+			require.NoError(t, json.Unmarshal([]byte(raw), &d))
+
+			draft := convertDraft(d)
+
+			assert.Equal(t, time.Unix(date, 0), draft.UpdatedAt, "UpdatedAt should fall back to date")
+			assert.Equal(t, time.Unix(date, 0), draft.CreatedAt, "CreatedAt should fall back to date")
+		})
+	}
+}
+
+// TestConvertDraft_ExplicitTimestampsWin verifies created_at/updated_at take
+// precedence over date when the API does provide them.
+func TestConvertDraft_ExplicitTimestampsWin(t *testing.T) {
+	date := int64(1782059501)
+	created := date - 3600
+	updated := date - 60
+
+	draft := convertDraft(draftResponse{
+		ID:        "draft-explicit",
+		Date:      ut(date),
+		CreatedAt: ut(created),
+		UpdatedAt: ut(updated),
+	})
+
+	assert.Equal(t, time.Unix(created, 0), draft.CreatedAt)
+	assert.Equal(t, time.Unix(updated, 0), draft.UpdatedAt)
 }

--- a/internal/cli/common/time.go
+++ b/internal/cli/common/time.go
@@ -152,7 +152,15 @@ func ParseHumanTime(input string, opts ParseHumanTimeOpts) (time.Time, error) {
 }
 
 // FormatTimeAgo formats a time as a relative string (e.g., "2 hours ago").
+// An unset timestamp — the zero value (year 1) or the Unix epoch, which is how
+// an omitted or null API timestamp typically decodes — renders as "unknown"
+// rather than a nonsensical "56 years ago". A genuine pre-1970 timestamp
+// (negative Unix seconds) is still formatted normally.
 func FormatTimeAgo(t time.Time) string {
+	if t.IsZero() || t.Unix() == 0 {
+		return "unknown"
+	}
+
 	now := time.Now()
 	diff := now.Sub(t)
 

--- a/internal/cli/common/time_test.go
+++ b/internal/cli/common/time_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -135,6 +136,28 @@ func TestFormatTimeAgo(t *testing.T) {
 			name:     "2 years ago",
 			time:     now.Add(-730 * 24 * time.Hour),
 			expected: "2 years ago",
+		},
+		{
+			// Zero value (year 1) — an omitted API timestamp. Must not render
+			// as "292 years ago".
+			name:     "zero time is unknown",
+			time:     time.Time{},
+			expected: "unknown",
+		},
+		{
+			// Unix epoch — a null API timestamp. Must not render as
+			// "56 years ago".
+			name:     "epoch is unknown",
+			time:     time.Unix(0, 0),
+			expected: "unknown",
+		},
+		{
+			// A genuine pre-1970 timestamp (negative Unix seconds) is real
+			// data, not "unset" — it must still format as a relative duration,
+			// not "unknown". Guards against an over-broad Unix() <= 0 check.
+			name:     "pre-1970 timestamp is not unknown",
+			time:     time.Unix(-100, 0),
+			expected: fmt.Sprintf("%d years ago", int(now.Sub(time.Unix(-100, 0)).Hours()/(24*365))),
 		},
 	}
 

--- a/internal/cli/email/drafts.go
+++ b/internal/cli/email/drafts.go
@@ -36,6 +36,7 @@ API reference: https://developer.nylas.com/docs/reference/api/drafts/`,
 
 func newDraftsListCmd() *cobra.Command {
 	var limit int
+	var showID bool
 
 	cmd := &cobra.Command{
 		Use:   "list [grant-id]",
@@ -59,9 +60,17 @@ func newDraftsListCmd() *cobra.Command {
 					return struct{}{}, nil
 				}
 
+				// Widen the ID column when --id shows full IDs (otherwise the
+				// IDs are truncated for a compact table).
+				idWidth := 15
+				if showID {
+					idWidth = 50
+				}
+
 				fmt.Printf("Found %d drafts:\n\n", len(drafts))
-				fmt.Printf("%-15s %-25s %-35s %s\n", "ID", "TO", "SUBJECT", "UPDATED")
-				fmt.Println("--------------------------------------------------------------------------------")
+				header := fmt.Sprintf("%-*s %-25s %-35s %s", idWidth, "ID", "TO", "SUBJECT", "UPDATED")
+				fmt.Println(header)
+				fmt.Println(strings.Repeat("-", len(header)))
 
 				for _, d := range drafts {
 					toStr := ""
@@ -76,12 +85,18 @@ func newDraftsListCmd() *cobra.Command {
 					}
 					subj = common.Truncate(subj, 33)
 
-					// Show first 12 chars of ID
-					idShort := common.Truncate(d.ID, 15)
-
 					dateStr := common.FormatTimeAgo(d.UpdatedAt)
 
-					fmt.Printf("%-15s %-25s %-35s %s\n", idShort, toStr, subj, common.Dim.Sprint(dateStr))
+					id := d.ID
+					if !showID {
+						id = common.Truncate(d.ID, 15)
+					}
+					fmt.Printf("%-*s %-25s %-35s %s\n", idWidth, id, toStr, subj, common.Dim.Sprint(dateStr))
+				}
+
+				if !showID {
+					fmt.Println()
+					_, _ = common.Dim.Printf("Use --id to see full draft IDs\n")
 				}
 
 				return struct{}{}, nil
@@ -91,6 +106,7 @@ func newDraftsListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().IntVarP(&limit, "limit", "l", 10, "Number of drafts to fetch")
+	cmd.Flags().BoolVar(&showID, "id", false, "Show full draft IDs")
 
 	return cmd
 }
@@ -304,7 +320,14 @@ func newDraftsShowCmd() *cobra.Command {
 			if len(draft.Cc) > 0 {
 				fmt.Printf("Cc:      %s\n", common.FormatParticipants(draft.Cc))
 			}
-			fmt.Printf("Updated: %s\n", draft.UpdatedAt.Format(common.DisplayDateTime))
+			// Mirror the list view: an unset timestamp (zero value or epoch,
+			// from the API omitting/nulling created_at/updated_at) shows as
+			// "unknown" rather than a nonsensical date.
+			updated := "unknown"
+			if !draft.UpdatedAt.IsZero() && draft.UpdatedAt.Unix() != 0 {
+				updated = draft.UpdatedAt.Format(common.DisplayDateTime)
+			}
+			fmt.Printf("Updated: %s\n", updated)
 
 			// Show attachments if any
 			if len(draft.Attachments) > 0 {

--- a/internal/cli/email/email_advanced_test.go
+++ b/internal/cli/email/email_advanced_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nylas/cli/internal/cli/common"
 	"github.com/nylas/cli/internal/domain"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,6 +72,21 @@ func TestDraftsCommand(t *testing.T) {
 		for _, expected := range expectedCmds {
 			assert.True(t, cmdMap[expected], "Missing expected subcommand: %s", expected)
 		}
+	})
+
+	t.Run("list_has_id_flag", func(t *testing.T) {
+		// The --id flag lets users retrieve full draft IDs (needed for
+		// show/send/delete) without resorting to --json. It matches the
+		// convention used by `email list`, `folders`, and `threads`.
+		var listCmd *cobra.Command
+		for _, sub := range cmd.Commands() {
+			if sub.Name() == "list" {
+				listCmd = sub
+				break
+			}
+		}
+		assert.NotNil(t, listCmd, "drafts list subcommand should exist")
+		assert.NotNil(t, listCmd.Flags().Lookup("id"), "drafts list should expose an --id flag")
 	})
 }
 


### PR DESCRIPTION
## Summary

`nylas email drafts list` rendered every draft's `UPDATED` column as **"56 years ago"**. The Nylas v3 drafts API omits `created_at`/`updated_at` (or sends them as `null`) and carries the real timestamp in a `date` field (Unix seconds) — the CLI mapped the missing field to the Unix epoch / zero time. There was also no way to read a draft's full ID from the table without falling back to `--json`.

Fixes [TW-5658](https://nylas.atlassian.net/browse/TW-5658).

## Changes

- **`internal/adapters/nylas/drafts.go`** — migrate `draftResponse` timestamp fields to `domain.UnixTime`; add `firstSetTime(primary, fallback)` so `created_at`/`updated_at` fall back to the `date` field when unset (handles both *omitted* → zero time and *null* → epoch).
- **`internal/cli/common/time.go`** — `FormatTimeAgo` now renders `"unknown"` for an unset timestamp (zero value or exact Unix epoch); a genuine pre-1970 time still formats normally.
- **`internal/cli/email/drafts.go`** — add `--id` flag to `drafts list` to show full draft IDs (matches the `email list` / `folders` / `threads` convention); the ID column width and the separator line scale together; `drafts show` guards an unset `UpdatedAt`.
- Tests added across the changed packages; `docs/COMMANDS.md` updated.

## Verification

- `make ci` green: fmt, vet, lint, unit, race, security scan, govulncheck (0), build.
- Live: drafts now show correct relative/absolute times; table aligns in both default and `--id` modes.
- Reviewed by Claude and Codex — both green.

### Before / after

```
# before
r-5185231233... hn@ycombinator.com   Flagged Show HN...   56 years ago

# after (default)
r-5185231233... hn@ycombinator.com   Flagged Show HN...   8 minutes ago

# after (--id)
r-5185231233890164434  hn@ycombinator.com  Flagged Show HN...  8 minutes ago
```

## Related docs

- [email drafts list](https://cli.nylas.com/docs/commands/email-drafts-list) — command + new `--id` flag
- [email drafts show](https://cli.nylas.com/docs/commands/email-drafts-show) — affected by the unset-timestamp guard
- [email list](https://cli.nylas.com/docs/commands/email-list) — existing `--id` flag convention this follows
- [Nylas v3 Drafts API reference](https://developer.nylas.com/docs/reference/api/drafts/) — referenced in the command help text


[TW-5658]: https://nylas.atlassian.net/browse/TW-5658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ