### PR TITLE
TW-5665: disable system keyring in TestValidateDefaultGrant (fix release test hang)

### DIFF
--- a/internal/cli/common/client_test.go
+++ b/internal/cli/common/client_test.go
@@ -460,6 +460,8 @@ func TestGrantFromDefault(t *testing.T) {
 func TestValidateDefaultGrant(t *testing.T) {
 	// Isolate any self-heal write to a throwaway cache location.
 	t.Setenv("HOME", t.TempDir())
+	// Avoid touching the real system keychain (hangs on locked CI runners).
+	t.Setenv("NYLAS_DISABLE_KEYRING", "true")
 	ctx := context.Background()
 
 	t.Run("removed default returns a clear, actionable error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

The [v3.1.26 release](https://github.com/nylas/cli/actions/runs/27961900023) failed at the **Run tests** step: the job hit the 10-minute timeout and panicked, so the tag/GoReleaser steps never ran and the release did not ship.

## Root cause

`TestValidateDefaultGrant/removed_default_returns_a_clear,_actionable_error` reached the **real** macOS keychain:

```
validateDefaultGrant (client.go:317)
  -> NewDefaultGrantStore (grantstore.go:31)
  -> migrateLegacyGrantStore (grantstore.go:46)
  -> keyring.NewSecretStore (keyring.go:73)
  -> SystemKeyring.IsAvailable (keyring.go:50)   // keyring.Set spawns macOS `security`
  -> os/exec Wait -> wait4   [blocked 9 minutes]
```

The test isolated `HOME` but not the keyring. On the CI macOS runner the keychain is locked, so the `security` subprocess blocked until the test timeout. It passes locally because the dev keychain is unlocked.

## Fix

Set `t.Setenv("NYLAS_DISABLE_KEYRING", "true")` in `TestValidateDefaultGrant` so it uses the encrypted-file fallback instead of the real keychain — matching the convention already used in `grantstore_test.go` and `remote_resources_test.go`.

## Verification

- `TestValidateDefaultGrant` was the only test hitting the real keychain under `go test ./... -short` (the air integration test is gated by `//go:build integration`; `TestProvidersCmd` skips on `testing.Short()` before its keyring call).
- Passes after the fix: `go test ./internal/cli/common/ -run TestValidateDefaultGrant`.

## Follow-up

Re-run the v3.1.26 release after merge. Nothing was partially released.

## Related docs

- [auth config](https://cli.nylas.com/docs/commands/auth-config) — credential storage / system keyring vs file store
- [auth status](https://cli.nylas.com/docs/commands/auth-status) — default grant resolution
- [admin grants list](https://cli.nylas.com/docs/commands/admin-grants-list) — grant lookup/validation

Jira: TW-5665
