### PR TITLE
test(air): fix flaky TestSyncEmails_DoesNotHoldRuntimeLockAcrossFetch CI failure

### DIFF
--- a/internal/air/handlers_email_cache_runtime_test.go
+++ b/internal/air/handlers_email_cache_runtime_test.go
@@ -595,7 +595,7 @@ func TestSyncEmails_DoesNotHoldRuntimeLockAcrossFetch(t *testing.T) {
 		// guarantee this test cares about is that the runtime lock is not held
 		// across the remote fetch, not that the full sync finishes within a tight
 		// local-only deadline.
-	case <-time.After(20 * time.Second):
+	case <-time.After(90 * time.Second):
 		t.Fatal("syncEmails did not finish after fetch was released")
 	}
 


### PR DESCRIPTION
## What

Bumps the completion deadline in `TestSyncEmails_DoesNotHoldRuntimeLockAcrossFetch` from **20s → 90s** (`internal/air/handlers_email_cache_runtime_test.go:598`).

## Why

The test starts `syncEmails` in a goroutine, verifies the runtime lock is **not held across the remote fetch** (via the `lockReleased` probe), then waits for the goroutine to finish. That final wait raced a hard-coded 20s wall-clock deadline.

Under the full `go test ./... -race` suite on a saturated GitHub runner (keyring ~96s, nylas ~120s, air/cache ~24s all overlapping under the race detector's ~10x slowdown), the post-fetch sync goroutine gets CPU-starved past 20s, so the timer fired and failed the test — even though the sync completes correctly. It reproduced twice on post-merge `main` CI ([run 1](https://github.com/nylas/cli/actions/runs/29089561504), [run 2](https://github.com/nylas/cli/actions/runs/29090762934)) then passed on retry with zero code changes — classic load-dependent flake. Locally it finishes in ~3s.

## The fix

The test's real assertion (lock not held across the fetch) is already verified earlier by `lockReleased` — that passed in both failures. The deadline only exists to reap the goroutine before cleanup closes the cache DB. Bumping to 90s gives ~30x headroom over the real ~3s runtime, well clear of any realistic runner starvation.

## Testing

- `go test ./internal/air/ -run TestSyncEmails_DoesNotHoldRuntimeLockAcrossFetch -race` — passes (~3.4s).

## Related docs

None — test-only change, no user-facing command, flag, or behavior is affected.